### PR TITLE
[Feat] 구글 소셜 로그인 구현

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,7 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="jbr-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.coil.compose)
     implementation(libs.foundation)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -90,6 +91,12 @@ dependencies {
 // OkHttp
     implementation(libs.okhttp)
     implementation(libs.logging.interceptor)
+
+// 카카오 로그인 SDK
+    implementation("com.kakao.sdk:v2-all:2.21.6")
+
+// 토큰 저장을 위한 DataStore
+    implementation ("androidx.datastore:datastore-preferences:1.1.1")
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     id("com.google.dagger.hilt.android")
+    id("com.google.gms.google-services")
     kotlin("kapt")
 }
 
@@ -101,6 +102,11 @@ dependencies {
 
 // 토큰 저장을 위한 DataStore
     implementation ("androidx.datastore:datastore-preferences:1.1.1")
+
+// 구글 로그인
+    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
+    implementation("com.google.firebase:firebase-auth")
+    implementation("com.google.android.gms:play-services-auth:21.2.0")
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("String", "BASE_URL", "\"${properties["BASE_URL"]}\"")
+        buildConfigField("String", "NATIVE_APP_KEY", "\"${properties["NATIVE_APP_KEY"]}\"")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,9 @@ android {
 
         buildConfigField("String", "BASE_URL", "\"${properties["BASE_URL"]}\"")
         buildConfigField("String", "NATIVE_APP_KEY", "\"${properties["NATIVE_APP_KEY"]}\"")
+        manifestPlaceholders += mapOf(
+            "NATIVE_APP_KEY" to properties["NATIVE_APP_KEY"] as String
+        )
     }
 
     buildTypes {

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,47 @@
+{
+  "project_info": {
+    "project_number": "353417813537",
+    "project_id": "thip-3a698",
+    "storage_bucket": "thip-3a698.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:353417813537:android:69029c2bc957df7fab4d60",
+        "android_client_info": {
+          "package_name": "com.texthip.thip"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "353417813537-lovs0p2tb9kjnjlp493a7098ov0cb2bu.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.texthip.thip",
+            "certificate_hash": "99315de9382f8b2903131eb4ae926a4739803ef1"
+          }
+        },
+        {
+          "client_id": "353417813537-ck9g1v0qprlb5nf4dvasinim403eng0f.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCFzpbeT-8JQCGxiSKuVXMvcNNYFtl6Fuo"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "353417813537-ck9g1v0qprlb5nf4dvasinim403eng0f.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,25 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Thip"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="${NATIVE_APP_KEY}" />
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="oauth"
+                    android:scheme="kakao${"NATIVE_APP_KEY"}" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -27,5 +46,4 @@
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
+                <!-- 리다이렉트 URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakao${NATIVE_APP_KEY}" />
+
+                <!--<data
                     android:host="oauth"
                     android:scheme="kakao${"NATIVE_APP_KEY"}" />
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".ThipApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,13 +28,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <!-- 리다이렉트 URI: "kakao${NATIVE_APP_KEY}://oauth" -->
                 <data android:host="oauth"
                     android:scheme="kakao${NATIVE_APP_KEY}" />
 
-                <!--<data
-                    android:host="oauth"
-                    android:scheme="kakao${"NATIVE_APP_KEY"}" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/texthip/thip/MainActivity.kt
+++ b/app/src/main/java/com/texthip/thip/MainActivity.kt
@@ -4,14 +4,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.texthip.thip.ui.navigator.navigations.commonNavigation
+import com.texthip.thip.ui.navigator.navigations.feedNavigation
+import com.texthip.thip.ui.navigator.navigations.groupNavigation
+import com.texthip.thip.ui.navigator.navigations.myPageNavigation
+import com.texthip.thip.ui.navigator.navigations.searchNavigation
+import com.texthip.thip.ui.navigator.routes.CommonRoutes
+import com.texthip.thip.ui.signin.screen.LoginScreen
+import com.texthip.thip.ui.signin.screen.SigninNicknameScreen
+import com.texthip.thip.ui.signin.screen.SplashScreen
 import com.texthip.thip.ui.theme.ThipTheme
-import com.texthip.thip.ui.theme.ThipTheme.colors
-import com.texthip.thip.ui.theme.ThipTheme.typography
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -21,63 +27,40 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ThipTheme {
-                /*Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }*/
-                MainScreen()
+                RootNavHost()
             }
         }
     }
 }
-
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Column {
-        Text(
-            text = "Hello $name!",
-            modifier = modifier,
-            style = typography.bigtitle_b700_s22_h24,
-            color = colors.Purple,
+fun RootNavHost() {
+    val navController = rememberNavController()
+    NavHost(
+        navController = navController,
+        startDestination = CommonRoutes.Splash
+    ) {
+        // --- 인증 관련 화면들 ---
+        composable<CommonRoutes.Splash> {
+            SplashScreen(navController = navController)
+        }
+        composable<CommonRoutes.Login> {
+            LoginScreen(navController = navController)
+        }
+        composable<CommonRoutes.Signup> {
+            SigninNicknameScreen(navController = navController)
+        }
+
+        // --- 메인 관련 화면들 ---
+        feedNavigation(navController)
+        groupNavigation(
+            navController = navController,
+            navigateBack = navController::popBackStack
         )
-
-        Text(
-            text = "Hello $name!",
-            modifier = modifier,
-            style = typography.smalltitle_sb600_s16_h20,
-            color = colors.NeonGreen,
+        searchNavigation(navController)
+        myPageNavigation(navController)
+        commonNavigation(
+            navController = navController,
+            navigateBack = navController::popBackStack
         )
-
-        Text(
-            text = "Hello $name!",
-            modifier = modifier,
-            style = typography.menu_sb600_s12,
-            color = colors.Red,
-        )
-
-        Text(
-            text = "Hello $name!",
-            modifier = modifier,
-            style = typography.navi_m500_s10,
-            color = colors.DarkGrey,
-        )
-
-        Text(
-            text = "Hello $name!",
-            modifier = modifier,
-            style = typography.view_r400_s11_h20,
-            color = colors.Black,
-        )
-    }
-
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    ThipTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/texthip/thip/ThipApplication.kt
+++ b/app/src/main/java/com/texthip/thip/ThipApplication.kt
@@ -12,6 +12,10 @@ class ThipApplication : Application(){
         super.onCreate()
 
         // 카카오 SDK 초기화
-        KakaoSdk.init(this, BuildConfig.NATIVE_APP_KEY)
+        try {
+            KakaoSdk.init(this, BuildConfig.NATIVE_APP_KEY)
+        }catch (e: Exception){
+            e.printStackTrace()
+        }
     }
 }

--- a/app/src/main/java/com/texthip/thip/ThipApplication.kt
+++ b/app/src/main/java/com/texthip/thip/ThipApplication.kt
@@ -1,7 +1,17 @@
 package com.texthip.thip
 
+import com.kakao.sdk.common.KakaoSdk
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import com.texthip.thip.BuildConfig
+
 
 @HiltAndroidApp
-class ThipApplication : Application()
+class ThipApplication : Application(){
+    override fun onCreate() {
+        super.onCreate()
+
+        // 카카오 SDK 초기화
+        KakaoSdk.init(this, BuildConfig.NATIVE_APP_KEY)
+    }
+}

--- a/app/src/main/java/com/texthip/thip/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/texthip/thip/data/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.texthip.thip.BuildConfig
+import com.texthip.thip.data.service.AuthService
 import com.texthip.thip.utils.auth.AuthInterceptor
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/texthip/thip/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/texthip/thip/data/di/NetworkModule.kt
@@ -67,4 +67,10 @@ object NetworkModule {
             )
             .client(okHttpClient)
             .build()
+
+    @Provides
+    @Singleton
+    fun provideAuthService(retrofit: Retrofit): AuthService {
+        return retrofit.create(AuthService::class.java)
+    }
 }

--- a/app/src/main/java/com/texthip/thip/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/texthip/thip/data/di/NetworkModule.kt
@@ -68,10 +68,4 @@ object NetworkModule {
             )
             .client(okHttpClient)
             .build()
-
-    @Provides
-    @Singleton
-    fun provideAuthService(retrofit: Retrofit): AuthService {
-        return retrofit.create(AuthService::class.java)
-    }
 }

--- a/app/src/main/java/com/texthip/thip/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/texthip/thip/data/di/ServiceModule.kt
@@ -1,5 +1,6 @@
 package com.texthip.thip.data.di
 
+import com.texthip.thip.data.service.AuthService
 import com.texthip.thip.data.service.BookService
 import com.texthip.thip.data.service.GroupService
 import com.texthip.thip.data.service.RoomsService
@@ -25,8 +26,15 @@ object ServiceModule {
     fun provideBookService(retrofit: Retrofit): BookService {
         return retrofit.create(BookService::class.java)
     }
+
     @Provides
     @Singleton
     fun providesRoomsService(retrofit: Retrofit): RoomsService =
         retrofit.create(RoomsService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideAuthService(retrofit: Retrofit): AuthService {
+        return retrofit.create(AuthService::class.java)
+    }
 }

--- a/app/src/main/java/com/texthip/thip/data/manager/TokenManager.kt
+++ b/app/src/main/java/com/texthip/thip/data/manager/TokenManager.kt
@@ -1,0 +1,46 @@
+package com.texthip.thip.data.manager
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TokenManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "thip_auth_tokens")
+
+    companion object {
+        //토큰저장에 사용되는 키
+        private val APP_TOKEN_KEY = stringPreferencesKey("app_token")
+    }
+
+    //토큰 저장
+    suspend fun saveToken(token: String) {
+        context.dataStore.edit { prefs ->
+            prefs[APP_TOKEN_KEY] = token
+        }
+    }
+
+    //저장된 토큰을 Flow 형태로 불러옴
+    fun getToken(): Flow<String?> {
+        return context.dataStore.data.map { prefs ->
+            prefs[APP_TOKEN_KEY]
+        }
+    }
+
+    //저장된 토큰 삭제 (로그아웃 시?)
+    suspend fun deleteToken() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(APP_TOKEN_KEY)
+        }
+    }
+}

--- a/app/src/main/java/com/texthip/thip/data/model/auth/request/AuthRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/auth/request/AuthRequest.kt
@@ -1,0 +1,8 @@
+package com.texthip.thip.data.model.auth.request
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthRequest(
+    @SerialName("oauth2Id") val oauth2Id: String
+)

--- a/app/src/main/java/com/texthip/thip/data/model/auth/response/AuthResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/auth/response/AuthResponse.kt
@@ -1,0 +1,10 @@
+package com.texthip.thip.data.model.auth.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthResponse(
+    @SerialName("token") val token: String,
+    @SerialName("isNewUser") val isNewUser: Boolean
+)

--- a/app/src/main/java/com/texthip/thip/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/AuthRepository.kt
@@ -1,0 +1,72 @@
+package com.texthip.thip.data.repository
+
+import android.content.Context
+import com.kakao.sdk.user.UserApiClient
+import com.texthip.thip.data.model.auth.request.AuthRequest
+import com.texthip.thip.data.model.auth.response.AuthResponse
+import com.texthip.thip.data.model.base.handleBaseResponse
+import com.texthip.thip.data.service.AuthService
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+@Singleton
+class AuthRepository @Inject constructor(
+    private val authService: AuthService
+) {
+
+    suspend fun loginWithKakao(context: Context): Result<AuthResponse?> {
+        return runCatching {
+            //카카오SDK를 통해 사용자 고유 ID 가져옴
+            val kakaoUserId = getKakaoUserId(context)
+
+            //신규/기존 유저인지 확인 요청
+             val request = AuthRequest(oauth2Id = "kakao_$kakaoUserId")
+            authService.checkNewUser(request)
+                .handleBaseResponse()
+                .getOrThrow()
+        }
+    }
+
+    //카카오 SDK 로그인 수행 -> 유저ID를 반환하는 suspend 메서드
+    private suspend fun getKakaoUserId(context: Context): Long = suspendCancellableCoroutine { continuation ->
+        // 카카오톡 설치 여부에 따라 로그인 방식 결정
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            // 카카오톡으로 로그인
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                if (error != null) {
+                    continuation.resumeWithException(error)
+                } else if (token != null) {
+                    // 로그인 성공 시 사용자 정보 요청
+                    fetchUserInfo(continuation)
+                }
+            }
+        } else {
+            // 카카오계정으로 로그인
+            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+                if (error != null) {
+                    continuation.resumeWithException(error)
+                } else if (token != null) {
+                    // 로그인 성공 시 사용자 정보 요청
+                    fetchUserInfo(continuation)
+                }
+            }
+        }
+    }
+
+    //사용자 정보를 가져오는 중복 코드를 별도의 함수로 분리함
+    private fun fetchUserInfo(continuation: CancellableContinuation<Long>) {
+        UserApiClient.instance.me { user, error ->
+            if (error != null) {
+                continuation.resumeWithException(error)
+            } else if (user?.id != null) {
+                continuation.resume(user.id!!)
+            } else {
+                continuation.resumeWithException(IllegalStateException("Kakao User ID is null"))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/texthip/thip/data/service/AuthService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/AuthService.kt
@@ -1,0 +1,15 @@
+package com.texthip.thip.data.service
+
+import com.texthip.thip.data.model.auth.request.AuthRequest
+import com.texthip.thip.data.model.auth.response.AuthResponse
+import com.texthip.thip.data.model.base.BaseResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+    //신규유저 여부 확인
+    @POST("oauth2/users")
+    suspend fun checkNewUser(
+        @Body request: AuthRequest
+    ): BaseResponse<AuthResponse>
+}

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/CommonRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/CommonRoutes.kt
@@ -6,4 +6,13 @@ import kotlinx.serialization.Serializable
 sealed class CommonRoutes : Routes() {
     @Serializable
     data object Alarm : CommonRoutes()
+
+    @Serializable
+    data object Splash : CommonRoutes()
+
+    @Serializable
+    data object Login : CommonRoutes()
+
+    @Serializable
+    data object Signup : CommonRoutes()
 }

--- a/app/src/main/java/com/texthip/thip/ui/signin/screen/LoginScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/screen/LoginScreen.kt
@@ -34,13 +34,14 @@ import androidx.navigation.NavController
 import com.texthip.thip.R
 import com.texthip.thip.data.manager.TokenManager
 import com.texthip.thip.ui.common.buttons.ActionMediumButton
+import com.texthip.thip.ui.navigator.routes.CommonRoutes
+import com.texthip.thip.ui.navigator.routes.MainTabRoutes
 import com.texthip.thip.ui.signin.viewmodel.LoginUiState
 import com.texthip.thip.ui.signin.viewmodel.LoginViewModel
 import com.texthip.thip.ui.theme.Purple
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 
@@ -58,18 +59,18 @@ fun LoginScreen(
     LaunchedEffect(key1 = uiState) {
         when (val state = uiState) {
             is LoginUiState.Success -> {
-                // TODO: TokenManager를 사용해 토큰 저장하는 로직 추가
-                coroutineScope.launch {
+                coroutineScope.launch { //토큰 저장
                     tokenManager.saveToken(state.response.token)
                 }
 
                 val destination = if (state.response.isNewUser) {
-                    // "회원가입 화면으로 이동"
+                    CommonRoutes.Signup
                 } else {
-                    // "홈 화면으로 이동"
+                    MainTabRoutes.Feed
                 }
-                // navController.navigate(destination)
-                Toast.makeText(context, "로그인 성공!", Toast.LENGTH_SHORT).show()
+                navController.navigate(destination) {
+                    popUpTo(CommonRoutes.Login) { inclusive = true }
+                }
                 viewModel.clearLoginState() // 상태 초기화
             }
 
@@ -90,9 +91,8 @@ fun LoginScreen(
         // 로딩 중일 때 화면 전체에 로딩 인디케이터 표시
         if (uiState is LoginUiState.Loading) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .align(Alignment.Center)
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize()
             ) {
                 CircularProgressIndicator()
             }

--- a/app/src/main/java/com/texthip/thip/ui/signin/screen/LoginScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/screen/LoginScreen.kt
@@ -1,20 +1,26 @@
 package com.texthip.thip.ui.signin.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.Unspecified
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -22,15 +28,82 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import com.texthip.thip.R
+import com.texthip.thip.data.manager.TokenManager
 import com.texthip.thip.ui.common.buttons.ActionMediumButton
+import com.texthip.thip.ui.signin.viewmodel.LoginUiState
+import com.texthip.thip.ui.signin.viewmodel.LoginViewModel
 import com.texthip.thip.ui.theme.Purple
+import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 
 @Composable
-fun LoginScreen() {
+fun LoginScreen(
+    navController: NavController,
+    viewModel: LoginViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value //by 오류로 인해 변경함
+    val coroutineScope = rememberCoroutineScope()
+    val tokenManager = remember { TokenManager(context) }
+
+    // uiState가 바뀔 때마다 실행되어 화면 이동이나 토스트 메시지 등을 처리
+    LaunchedEffect(key1 = uiState) {
+        when (val state = uiState) {
+            is LoginUiState.Success -> {
+                // TODO: TokenManager를 사용해 토큰 저장하는 로직 추가
+                coroutineScope.launch {
+                    tokenManager.saveToken(state.response.token)
+                }
+
+                val destination = if (state.response.isNewUser) {
+                    // "회원가입 화면으로 이동"
+                } else {
+                    // "홈 화면으로 이동"
+                }
+                // navController.navigate(destination)
+                Toast.makeText(context, "로그인 성공!", Toast.LENGTH_SHORT).show()
+                viewModel.clearLoginState() // 상태 초기화
+            }
+
+            is LoginUiState.Error -> {
+                Toast.makeText(context, state.message, Toast.LENGTH_SHORT).show()
+                viewModel.clearLoginState() // 상태 초기화
+            }
+            else -> {}
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        LoginContent(
+            onKakaoLoginClick = { viewModel.kakaoLogin(context) },
+            onGoogleLoginClick = { /* TODO: 구글 로그인 로직 연결 */ }
+        )
+
+        // 로딩 중일 때 화면 전체에 로딩 인디케이터 표시
+        if (uiState is LoginUiState.Loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .align(Alignment.Center)
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}
+@Composable
+fun LoginContent(
+    onKakaoLoginClick: () -> Unit,
+    onGoogleLoginClick: () -> Unit
+) {
     Column(
         Modifier
             .background(colors.Black)
@@ -64,7 +137,7 @@ fun LoginScreen() {
             backgroundColor = colors.KakaoYellow,
             hasRightIcon = false,
             modifier = Modifier.fillMaxWidth(),
-            onClick = {},
+            onClick = onKakaoLoginClick,
         )
         Spacer(modifier = Modifier.height(20.dp))
         ActionMediumButton(
@@ -75,13 +148,15 @@ fun LoginScreen() {
             backgroundColor = colors.White,
             hasRightIcon = false,
             modifier = Modifier.fillMaxWidth(),
-            onClick = {},
+            onClick = onGoogleLoginClick,
         )
     }
 }
 
 @Preview
 @Composable
-private fun LoginScreenPrev() {
-    LoginScreen()
+private fun LoginContentPreview() {
+    ThipTheme {
+        LoginContent(onKakaoLoginClick = {}, onGoogleLoginClick = {})
+    }
 }

--- a/app/src/main/java/com/texthip/thip/ui/signin/screen/SignupNicknameScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/screen/SignupNicknameScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.texthip.thip.R
 import com.texthip.thip.ui.common.forms.WarningTextField
 import com.texthip.thip.ui.common.topappbar.InputTopAppBar
@@ -29,11 +31,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
-fun SigninNicknameScreen() {
+fun SigninNicknameScreen(
+    navController: NavController,
+) {
     var nickname by rememberSaveable { mutableStateOf("") }
     var showWarning by remember { mutableStateOf(false) }
     var warningMessageResId by remember { mutableStateOf<Int?>(null) }
-    val isRightButtonEnabled by remember {derivedStateOf {nickname.isNotBlank()}} // 닉네임 공백 아닐때 버튼 활성화
+    val isRightButtonEnabled by remember { derivedStateOf { nickname.isNotBlank() } } // 닉네임 공백 아닐때 버튼 활성화
     val coroutineScope = rememberCoroutineScope()
 
     Column(
@@ -97,5 +101,6 @@ fun SigninNicknameScreen() {
 @Preview
 @Composable
 private fun SigninNicknameScreenPrev() {
-    SigninNicknameScreen()
+    val navController = rememberNavController()
+    SigninNicknameScreen(navController)
 }

--- a/app/src/main/java/com/texthip/thip/ui/signin/screen/SplashScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/screen/SplashScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.Unspecified
@@ -19,13 +20,30 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.texthip.thip.R
+import com.texthip.thip.ui.navigator.routes.CommonRoutes
 import com.texthip.thip.ui.theme.Purple
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
+import kotlinx.coroutines.delay
 
 @Composable
-fun SplashScreen() {
+fun SplashScreen(
+    navController: NavController,
+) {
+    LaunchedEffect(key1 = Unit) {
+        //3초 delay
+        delay(3000L)
+
+        // 로그인 화면으로 이동
+        navController.navigate(CommonRoutes.Login) {
+            popUpTo(CommonRoutes.Splash) {
+                inclusive = true
+            }
+        }
+    }
     Column(
         Modifier
             .background(colors.Black)
@@ -55,5 +73,6 @@ fun SplashScreen() {
 @Preview
 @Composable
 private fun SplashScreenPrev() {
-    SplashScreen()
+    val navController = rememberNavController()
+    SplashScreen(navController)
 }

--- a/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 sealed interface LoginUiState {
-    data object Idle : LoginUiState // 초기 상태
+    data object Idle : LoginUiState
     data object Loading : LoginUiState
     data class Success(val response: AuthResponse) : LoginUiState
     data class Error(val message: String) : LoginUiState
@@ -22,7 +22,7 @@ sealed interface LoginUiState {
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val authRepository: AuthRepository // 실제로는 AuthRepository를 주입받아야 합니다.
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
@@ -47,10 +47,15 @@ class LoginViewModel @Inject constructor(
                         LoginUiState.Error(throwable.message ?: "알 수 없는 통신 오류가 발생했습니다.")
                     }
                 }
+           /* //신규유저 아닌 경우 피드화면으로 테스트
+            val fakeToken = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjcsImlhdCI6MTc1NDM4MjY1MiwiZXhwIjoxNzU2OTc0NjUyfQ.5CrcGkff5rcwF25qSsw8BY_GZ4W9w7QMJ6kXlwW4Ub0"
+            val fakeResponse = AuthResponse(token = fakeToken, isNewUser = false)
+            _uiState.update { LoginUiState.Success(fakeResponse) }
+*/
         }
     }
 
-    // 화면 이동 또는 에러 메시지 표시 후, 상태를 다시 초기화하여 이벤트가 중복 실행되는 것을 방지
+    //상태를 다시 초기화-> 이벤트 중복 실행 방지
     fun clearLoginState() {
         _uiState.update { LoginUiState.Idle }
     }

--- a/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.texthip.thip.data.model.auth.response.AuthResponse
 import com.texthip.thip.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update

--- a/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
@@ -1,0 +1,57 @@
+package com.texthip.thip.ui.signin.viewmodel
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.texthip.thip.data.model.auth.response.AuthResponse
+import com.texthip.thip.data.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+sealed interface LoginUiState {
+    data object Idle : LoginUiState // 초기 상태
+    data object Loading : LoginUiState
+    data class Success(val response: AuthResponse) : LoginUiState
+    data class Error(val message: String) : LoginUiState
+}
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val authRepository: AuthRepository // 실제로는 AuthRepository를 주입받아야 합니다.
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
+    val uiState = _uiState.asStateFlow()
+
+    fun kakaoLogin(context: Context) {
+        viewModelScope.launch {
+            _uiState.update { LoginUiState.Loading }
+
+            //카카오 로그인부터 서버 통신까지
+            authRepository.loginWithKakao(context)
+                .onSuccess { response ->
+                    if (response != null) {
+                        _uiState.update { LoginUiState.Success(response) }
+                    } else {
+                        _uiState.update { LoginUiState.Error("서버로부터 응답을 받지 못했습니다.") }
+                    }
+                }
+                .onFailure { throwable ->
+                    Log.e("LoginViewModel", "Login failed: ${throwable.message}", throwable)
+                    _uiState.update {
+                        LoginUiState.Error(throwable.message ?: "알 수 없는 통신 오류가 발생했습니다.")
+                    }
+                }
+        }
+    }
+
+    // 화면 이동 또는 에러 메시지 표시 후, 상태를 다시 초기화하여 이벤트가 중복 실행되는 것을 방지
+    fun clearLoginState() {
+        _uiState.update { LoginUiState.Idle }
+    }
+}

--- a/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/viewmodel/KakaoLoginViewModel.kt
@@ -55,6 +55,28 @@ class LoginViewModel @Inject constructor(
         }
     }
 
+    fun googleLogin(idToken: String){
+        viewModelScope.launch {
+            _uiState.update { LoginUiState.Loading }
+
+            //구글 로그인부터 서버 통신까지
+            authRepository.loginWithGoogle(idToken)
+                .onSuccess { response ->
+                    if (response != null) {
+                        _uiState.update { LoginUiState.Success(response) }
+                    } else {
+                        _uiState.update { LoginUiState.Error("서버로부터 응답을 받지 못했습니다.") }
+                    }
+                }
+                .onFailure { throwable ->
+                    Log.e("LoginViewModel", "Login failed: ${throwable.message}", throwable)
+                    _uiState.update {
+                        LoginUiState.Error(throwable.message ?: "알 수 없는 통신 오류가 발생했습니다.")
+                    }
+                }
+        }
+    }
+
     //상태를 다시 초기화-> 이벤트 중복 실행 방지
     fun clearLoginState() {
         _uiState.update { LoginUiState.Idle }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,4 +374,7 @@
     <!-- GenreManager API constants -->
     <string name="api_genre_science_it" translatable="false">과학/IT</string>
 
+    <!-- Google login constants -->
+    <string name="default_web_client_id" translatable="false">353417813537-ck9g1v0qprlb5nf4dvasinim403eng0f.apps.googleusercontent.com</string>
+
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     id("com.google.dagger.hilt.android") version "2.57" apply false
+    id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ okhttp = "5.1.0"
 retrofit = "3.0.0"
 retrofitKotlinSerializationConverter = "1.0.0"
 androidxComposeNavigation = "2.8.2"
+lifecycleRuntimeCompose = "2.10.0-alpha01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -58,6 +59,7 @@ logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", ver
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-kotlin-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinSerializationConverter" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://devrepo.kakao.com/nexus/content/groups/public/")
     }
 }
 


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #77 

<br/>

## 🔎 작업 내용

-구글 소셜 로그인 구현했습니다.
- firebase 기반 구글 로그인입니다.
- 카카오와 마찬가지로, 사용자 고유 ID (UID) 를 추출해 서버로 요청을 보냅니다. 
 <br/>


## 📸 스크린샷  

https://github.com/user-attachments/assets/f29f1066-fa39-46c4-a13b-599ec0acfffd

신규 사용자인 경우, isNewUser = true , 임시 토큰 발급 확인 했습니다. 

<img width="1976" height="1084" alt="image" src="https://github.com/user-attachments/assets/5fec6d77-839d-4ee9-85d2-c5d1f0272afa" />

<img width="1042" height="363" alt="image" src="https://github.com/user-attachments/assets/e3f53040-539d-4e23-8b3e-c53453d99b58" />


<br/>

## 😢 해결하지 못한 과제
- [] TASK

  <br/>

## 📢 리뷰어들에게
- local.properties에 넣을 값 따로 없습니다! 

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카카오/구글 로그인 지원
  - 신규 사용자 회원가입(닉네임 입력) 플로우 추가
  - 로그인 토큰 저장으로 추후 자동 로그인 대비

- Refactor
  - 앱 시작 시 스플래시 후 로그인 화면으로 자연스러운 전환
  - 로딩 인디케이터와 오류 토스트 제공
  - 내비게이션 구조 정비로 화면 전환 일원화

- Chores
  - Firebase/Google Services 설정 추가
  - 인터넷 권한 및 필수 SDK/플러그인 의존성 구성
<!-- end of auto-generated comment: release notes by coderabbit.ai -->