### PR TITLE
[FEAT] 책 검색 화면 API 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    
     <application
         android:name=".ThipApplication"
         android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/texthip/thip/data/manager/Genre.kt
+++ b/app/src/main/java/com/texthip/thip/data/manager/Genre.kt
@@ -9,7 +9,7 @@ enum class Genre(
     val networkApiCategory: String = apiCategory
 ) {
     LITERATURE("literature", "문학"),
-    SCIENCE_IT("science_it", "과학·IT", "과학/IT"),
+    SCIENCE_IT("science_it", "과학·IT", "과학·IT"),
     SOCIAL_SCIENCE("social_science", "사회과학"),
     HUMANITIES("humanities", "인문학"),
     ART("art", "예술");

--- a/app/src/main/java/com/texthip/thip/data/model/book/request/BookSaveRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/request/BookSaveRequest.kt
@@ -1,8 +1,9 @@
 package com.texthip.thip.data.model.book.request
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookSaveRequest(
-    val type: Boolean
+    @SerialName("type") val type: Boolean
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/request/BookSaveRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/request/BookSaveRequest.kt
@@ -1,0 +1,8 @@
+package com.texthip.thip.data.model.book.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookSaveRequest(
+    val type: Boolean
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/request/BookSaveRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/request/BookSaveRequest.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookSaveRequest(
-    @SerialName("type") val type: Boolean
+    @SerialName("type") val type: Boolean = false
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookDetailResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookDetailResponse.kt
@@ -1,0 +1,16 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookDetailResponse(
+    val title: String,
+    val imageUrl: String,
+    val authorName: String,
+    val publisher: String,
+    val isbn: String,
+    val description: String,
+    val recruitingRoomCount: Int,
+    val readCount: Int,
+    val isSaved: Boolean
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookDetailResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookDetailResponse.kt
@@ -1,16 +1,17 @@
 package com.texthip.thip.data.model.book.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookDetailResponse(
-    val title: String,
-    val imageUrl: String,
-    val authorName: String,
-    val publisher: String,
-    val isbn: String,
-    val description: String,
-    val recruitingRoomCount: Int,
-    val readCount: Int,
-    val isSaved: Boolean
+    @SerialName("title") val title: String,
+    @SerialName("imageUrl") val imageUrl: String,
+    @SerialName("authorName") val authorName: String,
+    @SerialName("publisher") val publisher: String,
+    @SerialName("isbn") val isbn: String,
+    @SerialName("description") val description: String,
+    @SerialName("recruitingRoomCount") val recruitingRoomCount: Int,
+    @SerialName("readCount") val readCount: Int,
+    @SerialName("isSaved") val isSaved: Boolean
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookDetailResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookDetailResponse.kt
@@ -5,13 +5,13 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookDetailResponse(
-    @SerialName("title") val title: String,
-    @SerialName("imageUrl") val imageUrl: String,
-    @SerialName("authorName") val authorName: String,
-    @SerialName("publisher") val publisher: String,
-    @SerialName("isbn") val isbn: String,
-    @SerialName("description") val description: String,
-    @SerialName("recruitingRoomCount") val recruitingRoomCount: Int,
-    @SerialName("readCount") val readCount: Int,
-    @SerialName("isSaved") val isSaved: Boolean
+    @SerialName("title") val title: String = "",
+    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("authorName") val authorName: String = "",
+    @SerialName("publisher") val publisher: String = "",
+    @SerialName("isbn") val isbn: String = "",
+    @SerialName("description") val description: String = "",
+    @SerialName("recruitingRoomCount") val recruitingRoomCount: Int = 0,
+    @SerialName("readCount") val readCount: Int = 0,
+    @SerialName("isSaved") val isSaved: Boolean = false
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookListResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookListResponse.kt
@@ -6,14 +6,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookListResponse(
-    @SerialName("bookList") val bookList: List<BookSavedResponse>
+    @SerialName("bookList") val bookList: List<BookSavedResponse> = emptyList()
 )
 
 @Serializable
 data class BookSavedResponse(
-    @SerialName("isbn") val isbn: String,
-    @SerialName("bookTitle") val bookTitle: String,
-    @SerialName("authorName") val authorName: String,
-    @SerialName("publisher") val publisher: String,
-    @SerialName("imageUrl") val imageUrl: String?
+    @SerialName("isbn") val isbn: String = "",
+    @SerialName("bookTitle") val bookTitle: String = "",
+    @SerialName("authorName") val authorName: String = "",
+    @SerialName("publisher") val publisher: String = "",
+    @SerialName("imageUrl") val imageUrl: String? = null
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookSaveResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookSaveResponse.kt
@@ -1,9 +1,10 @@
 package com.texthip.thip.data.model.book.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookSaveResponse(
-    val isbn: String,
-    val isSaved: Boolean
+    @SerialName("isbn") val isbn: String,
+    @SerialName("isSaved") val isSaved: Boolean
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookSaveResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookSaveResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookSaveResponse(
-    @SerialName("isbn") val isbn: String,
-    @SerialName("isSaved") val isSaved: Boolean
+    @SerialName("isbn") val isbn: String = "",
+    @SerialName("isSaved") val isSaved: Boolean = false
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookSaveResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookSaveResponse.kt
@@ -1,0 +1,9 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookSaveResponse(
+    val isbn: String,
+    val isSaved: Boolean
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookSearchResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookSearchResponse.kt
@@ -1,0 +1,23 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookSearchResponse(
+    val searchResult: List<BookSearchItem>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Int,
+    val totalPages: Int,
+    val last: Boolean,
+    val first: Boolean
+)
+
+@Serializable
+data class BookSearchItem(
+    val title: String,
+    val imageUrl: String,
+    val authorName: String,
+    val publisher: String,
+    val isbn: String
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookSearchResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookSearchResponse.kt
@@ -5,20 +5,20 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookSearchResponse(
-    @SerialName("searchResult") val searchResult: List<BookSearchItem>,
-    @SerialName("page") val page: Int,
-    @SerialName("size") val size: Int,
-    @SerialName("totalElements") val totalElements: Int,
-    @SerialName("totalPages") val totalPages: Int,
-    @SerialName("last") val last: Boolean,
-    @SerialName("first") val first: Boolean
+    @SerialName("searchResult") val searchResult: List<BookSearchItem> = emptyList(),
+    @SerialName("page") val page: Int = 0,
+    @SerialName("size") val size: Int = 0,
+    @SerialName("totalElements") val totalElements: Int = 0,
+    @SerialName("totalPages") val totalPages: Int = 0,
+    @SerialName("last") val last: Boolean = true,
+    @SerialName("first") val first: Boolean = true
 )
 
 @Serializable
 data class BookSearchItem(
-    @SerialName("title") val title: String,
-    @SerialName("imageUrl") val imageUrl: String,
-    @SerialName("authorName") val authorName: String,
-    @SerialName("publisher") val publisher: String,
-    @SerialName("isbn") val isbn: String
+    @SerialName("title") val title: String = "",
+    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("authorName") val authorName: String = "",
+    @SerialName("publisher") val publisher: String = "",
+    @SerialName("isbn") val isbn: String = ""
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookSearchResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookSearchResponse.kt
@@ -1,23 +1,24 @@
 package com.texthip.thip.data.model.book.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookSearchResponse(
-    val searchResult: List<BookSearchItem>,
-    val page: Int,
-    val size: Int,
-    val totalElements: Int,
-    val totalPages: Int,
-    val last: Boolean,
-    val first: Boolean
+    @SerialName("searchResult") val searchResult: List<BookSearchItem>,
+    @SerialName("page") val page: Int,
+    @SerialName("size") val size: Int,
+    @SerialName("totalElements") val totalElements: Int,
+    @SerialName("totalPages") val totalPages: Int,
+    @SerialName("last") val last: Boolean,
+    @SerialName("first") val first: Boolean
 )
 
 @Serializable
 data class BookSearchItem(
-    val title: String,
-    val imageUrl: String,
-    val authorName: String,
-    val publisher: String,
-    val isbn: String
+    @SerialName("title") val title: String,
+    @SerialName("imageUrl") val imageUrl: String,
+    @SerialName("authorName") val authorName: String,
+    @SerialName("publisher") val publisher: String,
+    @SerialName("isbn") val isbn: String
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/MostSearchedBooksResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/MostSearchedBooksResponse.kt
@@ -1,0 +1,16 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MostSearchedBooksResponse(
+    val bookList: List<PopularBookItem>
+)
+
+@Serializable
+data class PopularBookItem(
+    val rank: Int,
+    val title: String,
+    val imageUrl: String,
+    val isbn: String
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/MostSearchedBooksResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/MostSearchedBooksResponse.kt
@@ -1,16 +1,17 @@
 package com.texthip.thip.data.model.book.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class MostSearchedBooksResponse(
-    val bookList: List<PopularBookItem>
+    @SerialName("bookList") val bookList: List<PopularBookItem>
 )
 
 @Serializable
 data class PopularBookItem(
-    val rank: Int,
-    val title: String,
-    val imageUrl: String,
-    val isbn: String
+    @SerialName("rank") val rank: Int,
+    @SerialName("title") val title: String,
+    @SerialName("imageUrl") val imageUrl: String,
+    @SerialName("isbn") val isbn: String
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/MostSearchedBooksResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/MostSearchedBooksResponse.kt
@@ -5,13 +5,13 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MostSearchedBooksResponse(
-    @SerialName("bookList") val bookList: List<PopularBookItem>
+    @SerialName("bookList") val bookList: List<PopularBookItem> = emptyList()
 )
 
 @Serializable
 data class PopularBookItem(
-    @SerialName("rank") val rank: Int,
-    @SerialName("title") val title: String,
-    @SerialName("imageUrl") val imageUrl: String,
-    @SerialName("isbn") val isbn: String
+    @SerialName("rank") val rank: Int = 0,
+    @SerialName("title") val title: String = "",
+    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("isbn") val isbn: String = ""
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/RecentSearchResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/RecentSearchResponse.kt
@@ -1,14 +1,15 @@
 package com.texthip.thip.data.model.book.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class RecentSearchResponse(
-    val recentSearchList: List<RecentSearchItem>
+    @SerialName("recentSearchList") val recentSearchList: List<RecentSearchItem>
 )
 
 @Serializable
 data class RecentSearchItem(
-    val recentSearchId: Int,
-    val searchTerm: String
+    @SerialName("recentSearchId") val recentSearchId: Int,
+    @SerialName("searchTerm") val searchTerm: String
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/RecentSearchResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/RecentSearchResponse.kt
@@ -1,0 +1,14 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RecentSearchResponse(
+    val recentSearchList: List<RecentSearchItem>
+)
+
+@Serializable
+data class RecentSearchItem(
+    val recentSearchId: Int,
+    val searchTerm: String
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/RecentSearchResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/RecentSearchResponse.kt
@@ -5,11 +5,11 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RecentSearchResponse(
-    @SerialName("recentSearchList") val recentSearchList: List<RecentSearchItem>
+    @SerialName("recentSearchList") val recentSearchList: List<RecentSearchItem> = emptyList()
 )
 
 @Serializable
 data class RecentSearchItem(
-    @SerialName("recentSearchId") val recentSearchId: Int,
-    @SerialName("searchTerm") val searchTerm: String
+    @SerialName("recentSearchId") val recentSearchId: Int = 0,
+    @SerialName("searchTerm") val searchTerm: String = ""
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/RecruitingRoomsResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/RecruitingRoomsResponse.kt
@@ -5,18 +5,18 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RecruitingRoomsResponse(
-    @SerialName("recruitingRoomList") val recruitingRoomList: List<RecruitingRoomItem>,
-    @SerialName("totalRoomCount") val totalRoomCount: Int,
-    @SerialName("nextCursor") val nextCursor: String?,
-    @SerialName("isLast") val isLast: Boolean
+    @SerialName("recruitingRoomList") val recruitingRoomList: List<RecruitingRoomItem> = emptyList(),
+    @SerialName("totalRoomCount") val totalRoomCount: Int = 0,
+    @SerialName("nextCursor") val nextCursor: String? = null,
+    @SerialName("isLast") val isLast: Boolean = true
 )
 
 @Serializable
 data class RecruitingRoomItem(
-    @SerialName("roomId") val roomId: Int,
-    @SerialName("bookImageUrl") val bookImageUrl: String,
-    @SerialName("roomName") val roomName: String,
-    @SerialName("memberCount") val memberCount: Int,
-    @SerialName("recruitCount") val recruitCount: Int,
-    @SerialName("deadlineEndDate") val deadlineEndDate: String
+    @SerialName("roomId") val roomId: Int = 0,
+    @SerialName("bookImageUrl") val bookImageUrl: String? = null,
+    @SerialName("roomName") val roomName: String = "",
+    @SerialName("memberCount") val memberCount: Int = 0,
+    @SerialName("recruitCount") val recruitCount: Int = 0,
+    @SerialName("deadlineEndDate") val deadlineEndDate: String = ""
 )

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/RecruitingRoomsResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/RecruitingRoomsResponse.kt
@@ -1,0 +1,21 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RecruitingRoomsResponse(
+    val recruitingRoomList: List<RecruitingRoomItem>,
+    val totalRoomCount: Int,
+    val nextCursor: String?,
+    val isLast: Boolean
+)
+
+@Serializable
+data class RecruitingRoomItem(
+    val roomId: Int,
+    val bookImageUrl: String,
+    val roomName: String,
+    val memberCount: Int,
+    val recruitCount: Int,
+    val deadlineEndDate: String
+)

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/RecruitingRoomsResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/RecruitingRoomsResponse.kt
@@ -1,21 +1,22 @@
 package com.texthip.thip.data.model.book.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class RecruitingRoomsResponse(
-    val recruitingRoomList: List<RecruitingRoomItem>,
-    val totalRoomCount: Int,
-    val nextCursor: String?,
-    val isLast: Boolean
+    @SerialName("recruitingRoomList") val recruitingRoomList: List<RecruitingRoomItem>,
+    @SerialName("totalRoomCount") val totalRoomCount: Int,
+    @SerialName("nextCursor") val nextCursor: String?,
+    @SerialName("isLast") val isLast: Boolean
 )
 
 @Serializable
 data class RecruitingRoomItem(
-    val roomId: Int,
-    val bookImageUrl: String,
-    val roomName: String,
-    val memberCount: Int,
-    val recruitCount: Int,
-    val deadlineEndDate: String
+    @SerialName("roomId") val roomId: Int,
+    @SerialName("bookImageUrl") val bookImageUrl: String,
+    @SerialName("roomName") val roomName: String,
+    @SerialName("memberCount") val memberCount: Int,
+    @SerialName("recruitCount") val recruitCount: Int,
+    @SerialName("deadlineEndDate") val deadlineEndDate: String
 )

--- a/app/src/main/java/com/texthip/thip/data/model/group/response/JoinedRoomListResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/group/response/JoinedRoomListResponse.kt
@@ -18,7 +18,7 @@ data class JoinedRoomListResponse(
 data class JoinedRoomResponse(
     @SerialName("roomId") val roomId: Int,
     @SerialName("bookImageUrl") val bookImageUrl: String?,
-    @SerialName("bookTitle") val bookTitle: String,
+    @SerialName("roomTitle") val roomTitle: String,
     @SerialName("memberCount") val memberCount: Int,
     @SerialName("userPercentage") val userPercentage: Int
 )

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -1,6 +1,7 @@
 package com.texthip.thip.data.repository
 
 import com.texthip.thip.data.model.base.handleBaseResponse
+import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecentSearchResponse
@@ -45,6 +46,13 @@ class BookRepository @Inject constructor(
     /** 최근 검색어 삭제 */
     suspend fun deleteRecentSearch(recentSearchId: Int): Result<Unit> = runCatching {
         bookService.deleteRecentSearch(recentSearchId)
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    /** 책 상세 조회 */
+    suspend fun getBookDetail(isbn: String): Result<BookDetailResponse?> = runCatching {
+        bookService.getBookDetail(isbn)
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -26,8 +26,8 @@ class BookRepository @Inject constructor(
     }
 
     /** 책 검색 */
-    suspend fun searchBooks(keyword: String, page: Int = 1): Result<BookSearchResponse?> = runCatching {
-        bookService.searchBooks(keyword, page)
+    suspend fun searchBooks(keyword: String, page: Int = 1, isFinalized: Boolean = false): Result<BookSearchResponse?> = runCatching {
+        bookService.searchBooks(keyword, page, isFinalized)
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -4,6 +4,7 @@ import com.texthip.thip.data.model.base.handleBaseResponse
 import com.texthip.thip.data.model.book.request.BookSaveRequest
 import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.BookSaveResponse
+import com.texthip.thip.data.model.book.response.BookSavedResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecentSearchResponse
@@ -18,7 +19,7 @@ class BookRepository @Inject constructor(
 ) {
 
     /** 저장된 책 또는 모임 책 목록 조회 */
-    suspend fun getBooks(type: String) = runCatching {
+    suspend fun getBooks(type: String): Result<List<BookSavedResponse>> = runCatching {
         bookService.getBooks(type)
             .handleBaseResponse()
             .getOrThrow()

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -7,6 +7,7 @@ import com.texthip.thip.data.model.book.response.BookSaveResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecentSearchResponse
+import com.texthip.thip.data.model.book.response.RecruitingRoomsResponse
 import com.texthip.thip.data.service.BookService
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -62,6 +63,13 @@ class BookRepository @Inject constructor(
     /** 책 저장/저장취소 */
     suspend fun saveBook(isbn: String, type: Boolean): Result<BookSaveResponse?> = runCatching {
         bookService.saveBook(isbn, BookSaveRequest(type))
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    /** 모집중인 방 조회 */
+    suspend fun getRecruitingRooms(isbn: String, cursor: String? = null): Result<RecruitingRoomsResponse?> = runCatching {
+        bookService.getRecruitingRooms(isbn, cursor)
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -1,6 +1,7 @@
 package com.texthip.thip.data.repository
 
 import com.texthip.thip.data.model.base.handleBaseResponse
+import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.service.BookService
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -16,5 +17,12 @@ class BookRepository @Inject constructor(
             .handleBaseResponse()
             .getOrThrow()
             ?.bookList ?: emptyList()
+    }
+
+    /** 책 검색 */
+    suspend fun searchBooks(keyword: String, page: Int = 1): Result<BookSearchResponse?> = runCatching {
+        bookService.searchBooks(keyword, page)
+            .handleBaseResponse()
+            .getOrThrow()
     }
 }

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -3,6 +3,7 @@ package com.texthip.thip.data.repository
 import com.texthip.thip.data.model.base.handleBaseResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
+import com.texthip.thip.data.model.book.response.RecentSearchResponse
 import com.texthip.thip.data.service.BookService
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -30,6 +31,20 @@ class BookRepository @Inject constructor(
     /** 인기 책 조회 */
     suspend fun getMostSearchedBooks(): Result<MostSearchedBooksResponse?> = runCatching {
         bookService.getMostSearchedBooks()
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    /** 최근 검색어 조회 */
+    suspend fun getRecentSearches(type: String = "BOOK"): Result<RecentSearchResponse?> = runCatching {
+        bookService.getRecentSearches(type)
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    /** 최근 검색어 삭제 */
+    suspend fun deleteRecentSearch(recentSearchId: Int): Result<Unit> = runCatching {
+        bookService.deleteRecentSearch(recentSearchId)
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.data.repository
 
 import com.texthip.thip.data.model.base.handleBaseResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
+import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.service.BookService
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,6 +23,13 @@ class BookRepository @Inject constructor(
     /** 책 검색 */
     suspend fun searchBooks(keyword: String, page: Int = 1): Result<BookSearchResponse?> = runCatching {
         bookService.searchBooks(keyword, page)
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    /** 인기 책 조회 */
+    suspend fun getMostSearchedBooks(): Result<MostSearchedBooksResponse?> = runCatching {
+        bookService.getMostSearchedBooks()
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -1,7 +1,9 @@
 package com.texthip.thip.data.repository
 
 import com.texthip.thip.data.model.base.handleBaseResponse
+import com.texthip.thip.data.model.book.request.BookSaveRequest
 import com.texthip.thip.data.model.book.response.BookDetailResponse
+import com.texthip.thip.data.model.book.response.BookSaveResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecentSearchResponse
@@ -53,6 +55,13 @@ class BookRepository @Inject constructor(
     /** 책 상세 조회 */
     suspend fun getBookDetail(isbn: String): Result<BookDetailResponse?> = runCatching {
         bookService.getBookDetail(isbn)
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    /** 책 저장/저장취소 */
+    suspend fun saveBook(isbn: String, type: Boolean): Result<BookSaveResponse?> = runCatching {
+        bookService.saveBook(isbn, BookSaveRequest(type))
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/GroupRepository.kt
@@ -65,23 +65,26 @@ class GroupRepository @Inject constructor(
     suspend fun getRoomRecruiting(roomId: Int): Result<RoomRecruitingResponse> = runCatching {
         groupService.getRoomRecruiting(roomId)
             .handleBaseResponse()
-            .getOrThrow()!!
+            .getOrThrow()
+            ?: throw NoSuchElementException("모집중인 모임방 정보를 찾을 수 없습니다.")
     }
 
     /** 새 모임방 생성 */
     suspend fun createRoom(request: CreateRoomRequest): Result<Int> = runCatching {
-        groupService.createRoom(request)
+        val response = groupService.createRoom(request)
             .handleBaseResponse()
-            .getOrThrow()!!
-            .roomId
+            .getOrThrow()
+            ?: throw NoSuchElementException("모임방 생성 응답을 받을 수 없습니다.")
+        response.roomId
     }
 
     /** 모임방 참여 또는 취소 */
     suspend fun joinOrCancelRoom(roomId: Int, type: String): Result<String> = runCatching {
         val request = RoomJoinRequest(type = type)
-        groupService.joinOrCancelRoom(roomId, request)
+        val response = groupService.joinOrCancelRoom(roomId, request)
             .handleBaseResponse()
-            .getOrThrow()!!
-            .type
+            .getOrThrow()
+            ?: throw NoSuchElementException("모임방 참여/취소 응답을 받을 수 없습니다.")
+        response.type
     }
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -8,6 +8,7 @@ import com.texthip.thip.data.model.book.response.BookSaveResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecentSearchResponse
+import com.texthip.thip.data.model.book.response.RecruitingRoomsResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -58,4 +59,11 @@ interface BookService {
         @Path("isbn") isbn: String,
         @Body request: BookSaveRequest
     ): BaseResponse<BookSaveResponse>
+
+    /** 모집중인 방 조회 */
+    @GET("books/{isbn}/recruiting-rooms")
+    suspend fun getRecruitingRooms(
+        @Path("isbn") isbn: String,
+        @Query("cursor") cursor: String? = null
+    ): BaseResponse<RecruitingRoomsResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -3,6 +3,7 @@ package com.texthip.thip.data.service
 import com.texthip.thip.data.model.base.BaseResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
+import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -20,4 +21,8 @@ interface BookService {
         @Query("keyword") keyword: String,
         @Query("page") page: Int = 1
     ): BaseResponse<BookSearchResponse>
+
+    /** 인기 책 조회 */
+    @GET("books/most-searched")
+    suspend fun getMostSearchedBooks(): BaseResponse<MostSearchedBooksResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -4,7 +4,10 @@ import com.texthip.thip.data.model.base.BaseResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
+import com.texthip.thip.data.model.book.response.RecentSearchResponse
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface BookService {
@@ -25,4 +28,16 @@ interface BookService {
     /** 인기 책 조회 */
     @GET("books/most-searched")
     suspend fun getMostSearchedBooks(): BaseResponse<MostSearchedBooksResponse>
+
+    /** 최근 검색어 조회 */
+    @GET("recent-searches")
+    suspend fun getRecentSearches(
+        @Query("type") type: String
+    ): BaseResponse<RecentSearchResponse>
+
+    /** 최근 검색어 삭제 */
+    @DELETE("recent-searches/{recentSearchId}")
+    suspend fun deleteRecentSearch(
+        @Path("recentSearchId") recentSearchId: Int
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -1,13 +1,17 @@
 package com.texthip.thip.data.service
 
 import com.texthip.thip.data.model.base.BaseResponse
+import com.texthip.thip.data.model.book.request.BookSaveRequest
 import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
+import com.texthip.thip.data.model.book.response.BookSaveResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecentSearchResponse
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -47,4 +51,11 @@ interface BookService {
     suspend fun getBookDetail(
         @Path("isbn") isbn: String
     ): BaseResponse<BookDetailResponse>
+
+    /** 책 저장/저장취소 */
+    @POST("books/{isbn}/saved")
+    suspend fun saveBook(
+        @Path("isbn") isbn: String,
+        @Body request: BookSaveRequest
+    ): BaseResponse<BookSaveResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.data.service
 
 import com.texthip.thip.data.model.base.BaseResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
+import com.texthip.thip.data.model.book.response.BookSearchResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -12,4 +13,11 @@ interface BookService {
     suspend fun getBooks(
         @Query("type") type: String
     ): BaseResponse<BookListResponse>
+
+    /** 책 검색 */
+    @GET("books")
+    suspend fun searchBooks(
+        @Query("keyword") keyword: String,
+        @Query("page") page: Int = 1
+    ): BaseResponse<BookSearchResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -28,7 +28,8 @@ interface BookService {
     @GET("books")
     suspend fun searchBooks(
         @Query("keyword") keyword: String,
-        @Query("page") page: Int = 1
+        @Query("page") page: Int = 1,
+        @Query("isFinalized") isFinalized: Boolean = false
     ): BaseResponse<BookSearchResponse>
 
     /** 인기 책 조회 */

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -1,6 +1,7 @@
 package com.texthip.thip.data.service
 
 import com.texthip.thip.data.model.base.BaseResponse
+import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
@@ -40,4 +41,10 @@ interface BookService {
     suspend fun deleteRecentSearch(
         @Path("recentSearchId") recentSearchId: Int
     ): BaseResponse<Unit>
+
+    /** 책 상세 조회 */
+    @GET("books/{isbn}")
+    suspend fun getBookDetail(
+        @Path("isbn") isbn: String
+    ): BaseResponse<BookDetailResponse>
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/buttons/GenreChipButton.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/buttons/GenreChipButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -34,6 +35,10 @@ fun GenreChipButton(
 ) {
     Box(
         modifier = modifier
+            .height(40.dp)
+            .clickable {
+                onClick()
+            }
             .border(
                 width = 1.dp,
                 color = colors.Grey02,

--- a/app/src/main/java/com/texthip/thip/ui/common/buttons/GenreChipButton.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/buttons/GenreChipButton.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.R
@@ -45,10 +44,8 @@ fun GenreChipButton(
                 shape = RoundedCornerShape(20.dp)
             )
             .background(color = Color.Transparent, shape = RoundedCornerShape(12.dp))
-            .padding(top = 8.dp, bottom = 8.dp, end = 8.dp, start = 12.dp)
-            .clickable {
-                onClick()
-            },
+            .padding(top = 8.dp, bottom = 8.dp, end = 8.dp, start = 12.dp),
+
         contentAlignment = Alignment.Center,
     ) {
         Row(
@@ -65,10 +62,10 @@ fun GenreChipButton(
                 contentDescription = null,
                 tint = Color.Unspecified,
                 modifier = Modifier
-                    .size(20.dp)
                     .clickable {
                         onCloseClick()
                     }
+                    .size(20.dp)
             )
         }
     }
@@ -84,7 +81,7 @@ private fun GenreChipButtonPreview() {
         verticalArrangement = Arrangement.spacedBy(30.dp, Alignment.CenterVertically),
     ) {
         GenreChipButton(
-            text = stringResource(R.string.essay),
+            text = "책",
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/buttons/GenreChipButton.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/buttons/GenreChipButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,6 +36,8 @@ fun GenreChipButton(
     Box(
         modifier = modifier
             .height(40.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(color = Color.Transparent, shape = RoundedCornerShape(12.dp))
             .clickable {
                 onClick()
             }
@@ -43,7 +46,6 @@ fun GenreChipButton(
                 color = colors.Grey02,
                 shape = RoundedCornerShape(20.dp)
             )
-            .background(color = Color.Transparent, shape = RoundedCornerShape(12.dp))
             .padding(top = 8.dp, bottom = 8.dp, end = 8.dp, start = 12.dp),
 
         contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/texthip/thip/ui/common/screen/RegisterBookScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/screen/RegisterBookScreen.kt
@@ -19,7 +19,10 @@ import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
 
 @Composable
-fun RegisterBookScreen(modifier: Modifier = Modifier) {
+fun RegisterBookScreen(
+    modifier: Modifier = Modifier,
+    onLeftClick: () -> Unit = {}
+) {
     Column(
         modifier = modifier
             .fillMaxSize(),
@@ -28,7 +31,7 @@ fun RegisterBookScreen(modifier: Modifier = Modifier) {
     ) {
         DefaultTopAppBar(
             title = stringResource(R.string.group_request_book),
-            onLeftClick = {},
+            onLeftClick = onLeftClick,
         )
         Column (
             modifier = Modifier

--- a/app/src/main/java/com/texthip/thip/ui/group/done/screen/GroupDoneScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/done/screen/GroupDoneScreen.kt
@@ -61,16 +61,16 @@ fun GroupDoneContent(
     val listState = rememberLazyListState()
 
     // 무한 스크롤을 위한 로직
-    val shouldLoadMore by remember {
+    val shouldLoadMore by remember(uiState.canLoadMore, uiState.isLoadingMore) {
         derivedStateOf {
             val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             val totalItems = listState.layoutInfo.totalItemsCount
-            lastVisibleIndex >= totalItems - 3 // 마지막 3개 아이템에 도달했을 때
+            uiState.canLoadMore && !uiState.isLoadingMore && totalItems > 0 && lastVisibleIndex >= totalItems - 3
         }
     }
 
     LaunchedEffect(shouldLoadMore) {
-        if (shouldLoadMore && uiState.canLoadMore) {
+        if (shouldLoadMore) {
             onLoadMore()
         }
     }

--- a/app/src/main/java/com/texthip/thip/ui/group/done/viewmodel/GroupDoneViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/done/viewmodel/GroupDoneViewModel.kt
@@ -78,6 +78,10 @@ class GroupDoneViewModel @Inject constructor(
                             }
                             nextCursor = response.nextCursor
                             isLastPage = response.isLast
+                        } ?: run {
+                            // null 응답 시 더 이상 로드할 수 없음을 명시
+                            updateState { it.copy(hasMore = false, isLoadingMore = false) }
+                            isLastPage = true
                         }
                     }
                     .onFailure { exception ->

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/component/GroupSelectBook.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/component/GroupSelectBook.kt
@@ -37,6 +37,7 @@ fun GroupSelectBook(
     onChangeBookClick: () -> Unit,
     onSelectBookClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isBookPreselected: Boolean = false
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -117,11 +118,13 @@ fun GroupSelectBook(
                         )
                     }
                 }
-                OptionChipButton(
-                    text = stringResource(R.string.change),
-                    onClick = onChangeBookClick,
-                    isSelected = false
-                )
+                if (!isBookPreselected) {
+                    OptionChipButton(
+                        text = stringResource(R.string.change),
+                        onClick = onChangeBookClick,
+                        isSelected = false
+                    )
+                }
             }
         }
     }
@@ -154,6 +157,19 @@ fun GroupSelectBookPreview_Selected() {
             selectedBook = dummyBook,
             onChangeBookClick = {},
             onSelectBookClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GroupSelectBookPreview_Preselected() {
+    ThipTheme {
+        GroupSelectBook(
+            selectedBook = dummyBook,
+            onChangeBookClick = {},
+            onSelectBookClick = {},
+            isBookPreselected = true
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/screen/GroupMakeRoomScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/screen/GroupMakeRoomScreen.kt
@@ -137,7 +137,8 @@ fun GroupMakeRoomContent(
                 GroupSelectBook(
                     selectedBook = uiState.selectedBook,
                     onChangeBookClick = { onToggleBookSearchSheet(true) },
-                    onSelectBookClick = { onToggleBookSearchSheet(true) }
+                    onSelectBookClick = { onToggleBookSearchSheet(true) },
+                    isBookPreselected = uiState.isBookPreselected
                 )
 
                 SectionDivider()

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/viewmodel/GroupMakeRoomUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/viewmodel/GroupMakeRoomUiState.kt
@@ -22,7 +22,8 @@ data class GroupMakeRoomUiState(
     val savedBooks: List<BookData> = emptyList(),
     val groupBooks: List<BookData> = emptyList(),
     val isLoadingBooks: Boolean = false,
-    val genres: List<Genre> = emptyList()
+    val genres: List<Genre> = emptyList(),
+    val isBookPreselected: Boolean = false
 ) {
     // 유효성 검사 로직
     val isDurationValid: Boolean

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/viewmodel/GroupMakeRoomViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/viewmodel/GroupMakeRoomViewModel.kt
@@ -54,6 +54,21 @@ class GroupMakeRoomViewModel @Inject constructor(
     fun selectBook(book: BookData) {
         updateState { it.copy(selectedBook = book) }
     }
+    
+    fun setPreselectedBook(isbn: String, title: String, imageUrl: String, author: String) {
+        val preselectedBook = BookData(
+            title = title,
+            imageUrl = imageUrl,
+            author = author,
+            isbn = isbn
+        )
+        updateState { 
+            it.copy(
+                selectedBook = preselectedBook,
+                isBookPreselected = true
+            ) 
+        }
+    }
 
     fun toggleBookSearchSheet(show: Boolean) {
         updateState { it.copy(showBookSearchSheet = show) }

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupMainCard.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupMainCard.kt
@@ -90,7 +90,7 @@ fun GroupMainCard(
                     Spacer(Modifier.height(2.dp))
                     // 제목
                     Text(
-                        text = data.bookTitle,
+                        text = data.roomTitle,
                         style = typography.smalltitle_sb600_s18_h24,
                         color = colors.Black,
                         maxLines = 1
@@ -171,7 +171,7 @@ fun PreviewMyGroupMainCard() {
         GroupMainCard(
             data = JoinedRoomResponse(
                 roomId = 1,
-                bookTitle = "호르몬 체인지 완독하는 방",
+                roomTitle = "호르몬 체인지 완독하는 방",
                 memberCount = 22,
                 bookImageUrl = "https://picsum.photos/300/200?1",
                 userPercentage = 40

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupPager.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupPager.kt
@@ -143,21 +143,21 @@ fun PreviewMyGroupPager() {
         val list = listOf(
             JoinedRoomResponse(
                 roomId = 1,
-                bookTitle = "호르몬 체인지 완독하는 방",
+                roomTitle = "호르몬 체인지 완독하는 방",
                 memberCount = 22,
                 bookImageUrl = "https://picsum.photos/300/200?1",
                 userPercentage = 40
             ),
             JoinedRoomResponse(
                 roomId = 2,
-                bookTitle = "명작 읽기방",
+                roomTitle = "명작 읽기방",
                 memberCount = 10,
                 bookImageUrl = "https://picsum.photos/300/200?2",
                 userPercentage = 70
             ),
             JoinedRoomResponse(
                 roomId = 3,
-                bookTitle = "또 다른 방",
+                roomTitle = "또 다른 방",
                 memberCount = 13,
                 bookImageUrl = "https://picsum.photos/300/200?3",
                 userPercentage = 10
@@ -174,7 +174,7 @@ fun PreviewSingleGroupPager() {
         val single = listOf(
             JoinedRoomResponse(
                 roomId = 4,
-                bookTitle = "단일 그룹",
+                roomTitle = "단일 그룹",
                 memberCount = 15,
                 bookImageUrl = "https://picsum.photos/300/200?4",
                 userPercentage = 60

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/screen/GroupMyScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/screen/GroupMyScreen.kt
@@ -71,16 +71,16 @@ fun GroupMyContent(
     val listState = rememberLazyListState()
     
     // 무한 스크롤 로직
-    val shouldLoadMore by remember {
+    val shouldLoadMore by remember(uiState.canLoadMore, uiState.isLoadingMore) {
         derivedStateOf {
             val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             val totalItems = listState.layoutInfo.totalItemsCount
-            lastVisibleIndex >= totalItems - 3
+            uiState.canLoadMore && !uiState.isLoadingMore && totalItems > 0 && lastVisibleIndex >= totalItems - 3
         }
     }
     
     LaunchedEffect(shouldLoadMore) {
-        if (shouldLoadMore && uiState.canLoadMore) {
+        if (shouldLoadMore) {
             onLoadMore()
         }
     }

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/viewmodel/GroupMyViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/viewmodel/GroupMyViewModel.kt
@@ -60,6 +60,10 @@ class GroupMyViewModel @Inject constructor(
                             }
                             nextCursor = response.nextCursor
                             isLastPage = response.isLast
+                        } ?: run {
+                            // null 응답 시 더 이상 로드할 수 없음을 명시
+                            updateState { it.copy(hasMore = false) }
+                            isLastPage = true
                         }
                     }
                     .onFailure { exception ->

--- a/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomRecruitScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomRecruitScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -100,6 +102,7 @@ fun GroupRoomRecruitContent(
     onHideToast: () -> Unit = {}
 ) {
     val context = LocalContext.current
+    val scrollState = rememberScrollState()
 
     Box(Modifier.fillMaxSize()) {
         // 로딩 상태
@@ -160,6 +163,7 @@ fun GroupRoomRecruitContent(
                     Modifier
                         .fillMaxSize()
                         .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
+                        .verticalScroll(scrollState)
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -193,21 +193,21 @@ fun PreviewGroupScreen() {
                     com.texthip.thip.data.model.group.response.JoinedRoomResponse(
                         roomId = 1,
                         bookImageUrl = "https://picsum.photos/300/400?joined1",
-                        bookTitle = "미드나이트 라이브러리",
+                        roomTitle = "미드나이트 라이브러리",
                         memberCount = 18,
                         userPercentage = 75
                     ),
                     com.texthip.thip.data.model.group.response.JoinedRoomResponse(
                         roomId = 2,
                         bookImageUrl = "https://picsum.photos/300/400?joined2",
-                        bookTitle = "코스모스",
+                        roomTitle = "코스모스",
                         memberCount = 25,
                         userPercentage = 42
                     ),
                     com.texthip.thip.data.model.group.response.JoinedRoomResponse(
                         roomId = 3,
                         bookImageUrl = "https://picsum.photos/300/400?joined3",
-                        bookTitle = "사피엔스",
+                        roomTitle = "사피엔스",
                         memberCount = 15,
                         userPercentage = 88
                     )

--- a/app/src/main/java/com/texthip/thip/ui/group/viewmodel/GroupViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/viewmodel/GroupViewModel.kt
@@ -89,6 +89,9 @@ class GroupViewModel @Inject constructor(
                             }
                             loadedPagesCount++
                             currentMyGroupsPage = page + 1
+                        } ?: run {
+                            // null 응답 시 더 이상 로드할 수 없음을 명시
+                            updateState { it.copy(hasMoreMyGroups = false) }
                         }
                     }
                     .onFailure {

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/CommonNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/CommonNavigationExtensions.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.ui.navigator.extensions
 
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
+import com.texthip.thip.ui.navigator.routes.CommonRoutes
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
 
 
@@ -35,4 +36,8 @@ fun NavDestination.isRoute(targetRoute: MainTabRoutes): Boolean {
     return route == targetRoute::class.qualifiedName
 }
 
+// 공통 화면 네비게이션
+fun NavHostController.navigateToRegisterBook() {
+    navigate(CommonRoutes.RegisterBook)
+}
 

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
@@ -16,6 +16,21 @@ fun NavHostController.navigateToGroupMakeRoom() {
     navigate(GroupRoutes.MakeRoom)
 }
 
+// 책 정보가 미리 선택된 모임방 만들기 화면으로 이동
+fun NavHostController.navigateToGroupMakeRoomWithBook(
+    isbn: String,
+    title: String,
+    imageUrl: String,
+    author: String
+) {
+    navigate(GroupRoutes.MakeRoomWithBook(
+        isbn = isbn,
+        title = title,
+        imageUrl = imageUrl,
+        author = author
+    ))
+}
+
 // 완료된 모임방 목록으로 이동
 fun NavHostController.navigateToGroupDone() {
     navigate(GroupRoutes.Done)

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/SearchNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/SearchNavigationExtensions.kt
@@ -13,3 +13,7 @@ fun NavHostController.navigateToSearch() {
 fun NavHostController.navigateToBookDetail(isbn: String) {
     navigate(SearchRoutes.BookDetail(isbn = isbn))
 }
+
+fun NavHostController.navigateToBookGroup(isbn: String) {
+    navigate(SearchRoutes.BookGroup(isbn = isbn))
+}

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/SearchNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/SearchNavigationExtensions.kt
@@ -2,9 +2,14 @@ package com.texthip.thip.ui.navigator.extensions
 
 import androidx.navigation.NavHostController
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
+import com.texthip.thip.ui.navigator.routes.SearchRoutes
 
 
 // Search 관련 네비게이션 확장 함수들
 fun NavHostController.navigateToSearch() {
     navigate(MainTabRoutes.Search)
+}
+
+fun NavHostController.navigateToBookDetail(isbn: String) {
+    navigate(SearchRoutes.BookDetail(isbn = isbn))
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/CommonNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/CommonNavigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.texthip.thip.ui.common.alarmpage.screen.AlarmScreen
 import com.texthip.thip.ui.common.alarmpage.viewmodel.AlarmViewModel
+import com.texthip.thip.ui.common.screen.RegisterBookScreen
 import com.texthip.thip.ui.navigator.routes.CommonRoutes
 
 // Common 관련 네비게이션
@@ -24,6 +25,13 @@ fun NavGraphBuilder.commonNavigation(
             alarmItems = alarmItems,
             onCardClick = { alarmViewModel.onCardClick(it) },
             onNavigateBack = navigateBack
+        )
+    }
+    
+    // 책 요청 화면
+    composable<CommonRoutes.RegisterBook> {
+        RegisterBookScreen(
+            onLeftClick = navigateBack
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
@@ -95,6 +95,32 @@ fun NavGraphBuilder.groupNavigation(
         )
     }
     
+    // Group MakeRoom 화면 (책 정보 미리 선택됨)
+    composable<GroupRoutes.MakeRoomWithBook> { backStackEntry ->
+        val route = backStackEntry.toRoute<GroupRoutes.MakeRoomWithBook>()
+        val viewModel: GroupMakeRoomViewModel = hiltViewModel()
+        
+        // 책 정보를 ViewModel에 미리 설정
+        LaunchedEffect(route) {
+            viewModel.setPreselectedBook(
+                isbn = route.isbn,
+                title = route.title,
+                imageUrl = route.imageUrl,
+                author = route.author
+            )
+        }
+        
+        GroupMakeRoomScreen(
+            viewModel = viewModel,
+            onNavigateBack = {
+                navigateBack()
+            },
+            onGroupCreated = {
+                navigateBack()
+            }
+        )
+    }
+    
     // Group Done 화면
     composable<GroupRoutes.Done> {
         GroupDoneScreen(

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.texthip.thip.ui.navigator.extensions.navigateToBookDetail
 import com.texthip.thip.ui.navigator.extensions.navigateToBookGroup
+import com.texthip.thip.ui.navigator.extensions.navigateToRegisterBook
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
 import com.texthip.thip.ui.navigator.routes.SearchRoutes
 import com.texthip.thip.ui.search.screen.SearchBookScreen
@@ -17,6 +18,9 @@ fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
         SearchBookScreen(
             onBookClick = { isbn ->
                 navController.navigateToBookDetail(isbn)
+            },
+            onRequestBook = {
+                navController.navigateToRegisterBook()
             }
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
@@ -5,10 +5,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.texthip.thip.ui.navigator.extensions.navigateToBookDetail
+import com.texthip.thip.ui.navigator.extensions.navigateToBookGroup
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
 import com.texthip.thip.ui.navigator.routes.SearchRoutes
 import com.texthip.thip.ui.search.screen.SearchBookScreen
 import com.texthip.thip.ui.search.screen.SearchBookDetailScreen
+import com.texthip.thip.ui.search.screen.SearchBookGroupScreen
 
 fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
     composable<MainTabRoutes.Search> {
@@ -32,13 +34,28 @@ fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
                 // TODO: 우측 버튼 액션 구현
             },
             onRecruitingGroupClick = {
-                // TODO: 모집중인 그룹 화면으로 이동
-            },
-            onBookMarkClick = { isBookmarked ->
-                // TODO: 북마크 액션 구현
+                navController.navigateToBookGroup(isbn)
             },
             onWriteFeedClick = {
                 // TODO: 피드 작성 화면으로 이동
+            }
+        )
+    }
+    
+    composable<SearchRoutes.BookGroup> { backStackEntry ->
+        val route = backStackEntry.toRoute<SearchRoutes.BookGroup>()
+        val isbn = route.isbn
+        
+        SearchBookGroupScreen(
+            isbn = isbn,
+            onLeftClick = {
+                navController.popBackStack()
+            },
+            onCardClick = { roomId ->
+                // TODO: 그룹 상세 화면으로 이동
+            },
+            onCreateRoomClick = {
+                // TODO: 방 생성 화면으로 이동
             }
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
@@ -3,14 +3,43 @@ package com.texthip.thip.ui.navigator.navigations
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import com.texthip.thip.ui.navigator.extensions.navigateToBookDetail
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
+import com.texthip.thip.ui.navigator.routes.SearchRoutes
 import com.texthip.thip.ui.search.screen.SearchBookScreen
+import com.texthip.thip.ui.search.screen.SearchBookDetailScreen
 
 fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
     composable<MainTabRoutes.Search> {
         SearchBookScreen(
-            navController = navController
-            // TODO: popularBooks를 서버에서 가져와서 전달
+            onBookClick = { isbn ->
+                navController.navigateToBookDetail(isbn)
+            }
+        )
+    }
+    
+    composable<SearchRoutes.BookDetail> { backStackEntry ->
+        val route = backStackEntry.toRoute<SearchRoutes.BookDetail>()
+        val isbn = route.isbn
+        
+        SearchBookDetailScreen(
+            isbn = isbn,
+            onLeftClick = {
+                navController.popBackStack()
+            },
+            onRightClick = {
+                // TODO: 우측 버튼 액션 구현
+            },
+            onRecruitingGroupClick = {
+                // TODO: 모집중인 그룹 화면으로 이동
+            },
+            onBookMarkClick = { isBookmarked ->
+                // TODO: 북마크 액션 구현
+            },
+            onWriteFeedClick = {
+                // TODO: 피드 작성 화면으로 이동
+            }
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
@@ -8,6 +8,9 @@ import com.texthip.thip.ui.search.screen.SearchBookScreen
 
 fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
     composable<MainTabRoutes.Search> {
-        SearchBookScreen(navController = navController)
+        SearchBookScreen(
+            navController = navController
+            // TODO: popularBooks를 서버에서 가져와서 전달
+        )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.texthip.thip.ui.navigator.extensions.navigateToBookDetail
 import com.texthip.thip.ui.navigator.extensions.navigateToBookGroup
+import com.texthip.thip.ui.navigator.extensions.navigateToGroupMakeRoomWithBook
 import com.texthip.thip.ui.navigator.extensions.navigateToGroupRecruit
 import com.texthip.thip.ui.navigator.extensions.navigateToRegisterBook
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
@@ -59,8 +60,13 @@ fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
             onCardClick = { roomId ->
                 navController.navigateToGroupRecruit(roomId)
             },
-            onCreateRoomClick = {
-                // TODO: 방 생성 화면으로 이동
+            onCreateRoomClick = { isbn, title, imageUrl, author ->
+                navController.navigateToGroupMakeRoomWithBook(
+                    isbn = isbn,
+                    title = title,
+                    imageUrl = imageUrl,
+                    author = author
+                )
             }
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/SearchNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.texthip.thip.ui.navigator.extensions.navigateToBookDetail
 import com.texthip.thip.ui.navigator.extensions.navigateToBookGroup
+import com.texthip.thip.ui.navigator.extensions.navigateToGroupRecruit
 import com.texthip.thip.ui.navigator.extensions.navigateToRegisterBook
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
 import com.texthip.thip.ui.navigator.routes.SearchRoutes
@@ -56,7 +57,7 @@ fun NavGraphBuilder.searchNavigation(navController: NavHostController) {
                 navController.popBackStack()
             },
             onCardClick = { roomId ->
-                // TODO: 그룹 상세 화면으로 이동
+                navController.navigateToGroupRecruit(roomId)
             },
             onCreateRoomClick = {
                 // TODO: 방 생성 화면으로 이동

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/CommonRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/CommonRoutes.kt
@@ -6,4 +6,7 @@ import kotlinx.serialization.Serializable
 sealed class CommonRoutes : Routes() {
     @Serializable
     data object Alarm : CommonRoutes()
+    
+    @Serializable
+    data object RegisterBook : CommonRoutes()
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
@@ -8,6 +8,14 @@ sealed class GroupRoutes : Routes() {
     data object MakeRoom : GroupRoutes()
     
     @Serializable
+    data class MakeRoomWithBook(
+        val isbn: String,
+        val title: String,
+        val imageUrl: String,
+        val author: String
+    ) : GroupRoutes()
+    
+    @Serializable
     data object Done : GroupRoutes()
     
     @Serializable

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/SearchRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/SearchRoutes.kt
@@ -4,7 +4,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 sealed class SearchRoutes : Routes() {
+    @Serializable
+    data class BookDetail(val isbn: String) : SearchRoutes()
+    
     // 향후 추가될 Search 관련 화면들
-    // @Serializable data object BookDetail : SearchRoutes
     // @Serializable data object BookGroup : SearchRoutes
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/SearchRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/SearchRoutes.kt
@@ -7,6 +7,6 @@ sealed class SearchRoutes : Routes() {
     @Serializable
     data class BookDetail(val isbn: String) : SearchRoutes()
     
-    // 향후 추가될 Search 관련 화면들
-    // @Serializable data object BookGroup : SearchRoutes
+    @Serializable
+    data class BookGroup(val isbn: String) : SearchRoutes()
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
@@ -2,13 +2,23 @@ package com.texthip.thip.ui.search.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.ui.search.mock.BookData
@@ -17,26 +27,67 @@ import com.texthip.thip.ui.theme.ThipTheme.colors
 
 @Composable
 fun SearchActiveField(
-    bookList: List<BookData>
+    bookList: List<BookData>,
+    isLoading: Boolean = false,
+    hasMore: Boolean = true,
+    onLoadMore: () -> Unit = {}
 ) {
+    val listState = rememberLazyListState()
+    
+    // 무한 스크롤을 위한 로직
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val layoutInfo = listState.layoutInfo
+            val totalItemsCount = layoutInfo.totalItemsCount
+            val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
+
+            hasMore && !isLoading && lastVisibleItemIndex >= totalItemsCount - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) {
+            onLoadMore()
+        }
+    }
+    
     LazyColumn(
-        verticalArrangement = Arrangement.Center
+        state = listState,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         itemsIndexed(bookList) { index, book ->
-            CardBookList(
-                title = book.title,
-                author = book.author,
-                publisher = book.publisher,
-                imageUrl = book.imageUrl
-            )
-            if (index < bookList.size - 1) {
-                Spacer(
-                    modifier = Modifier
-                        .padding(top = 12.dp, bottom = 12.dp)
-                        .fillMaxWidth()
-                        .height(1.dp)
-                        .background(colors.DarkGrey02)
+            Column {
+                CardBookList(
+                    title = book.title,
+                    author = book.author,
+                    publisher = book.publisher,
+                    imageUrl = book.imageUrl
                 )
+                if (index < bookList.size - 1) {
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(colors.DarkGrey02)
+                    )
+                }
+            }
+        }
+        
+        // 로딩 인디케이터
+        if (isLoading) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = colors.White
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
@@ -43,7 +43,7 @@ fun SearchActiveField(
             val totalItemsCount = layoutInfo.totalItemsCount
             val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
 
-            hasMore && !isLoading && lastVisibleItemIndex >= totalItemsCount - 3
+            hasMore && !isLoading && totalItemsCount > 0 && lastVisibleItemIndex >= totalItemsCount - 3
         }
     }
 

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
@@ -1,6 +1,7 @@
 package com.texthip.thip.ui.search.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,7 +31,8 @@ fun SearchActiveField(
     bookList: List<BookData>,
     isLoading: Boolean = false,
     hasMore: Boolean = true,
-    onLoadMore: () -> Unit = {}
+    onLoadMore: () -> Unit = {},
+    onBookClick: (BookData) -> Unit = {}
 ) {
     val listState = rememberLazyListState()
     
@@ -58,6 +60,7 @@ fun SearchActiveField(
         itemsIndexed(bookList) { index, book ->
             Column {
                 CardBookList(
+                    modifier = Modifier.clickable { onBookClick(book) },
                     title = book.title,
                     author = book.author,
                     publisher = book.publisher,

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchActiveField.kt
@@ -37,7 +37,7 @@ fun SearchActiveField(
     val listState = rememberLazyListState()
     
     // 무한 스크롤을 위한 로직
-    val shouldLoadMore by remember {
+    val shouldLoadMore by remember(hasMore, isLoading) {
         derivedStateOf {
             val layoutInfo = listState.layoutInfo
             val totalItemsCount = layoutInfo.totalItemsCount

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
@@ -2,24 +2,32 @@ package com.texthip.thip.ui.search.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.R
-import com.texthip.thip.ui.search.mock.BookData
 import com.texthip.thip.ui.common.cards.CardBookList
+import com.texthip.thip.ui.search.mock.BookData
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
@@ -27,8 +35,30 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 @Composable
 fun SearchBookFilteredResult(
     resultCount: Int,
-    bookList: List<BookData>
+    bookList: List<BookData>,
+    isLoading: Boolean = false,
+    hasMore: Boolean = true,
+    onLoadMore: () -> Unit = {}
 ) {
+    val listState = rememberLazyListState()
+    
+    // 무한 스크롤을 위한 로직
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val layoutInfo = listState.layoutInfo
+            val totalItemsCount = layoutInfo.totalItemsCount
+            val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
+
+            hasMore && !isLoading && lastVisibleItemIndex >= totalItemsCount - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) {
+            onLoadMore()
+        }
+    }
+    
     Column {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -48,7 +78,7 @@ fun SearchBookFilteredResult(
                 .background(colors.DarkGrey02)
         )
 
-        if (bookList.isEmpty()) {
+        if (bookList.isEmpty() && !isLoading) {
             SearchEmptyResult(
                 mainText = stringResource(R.string.book_no_search_result1),
                 subText = stringResource(R.string.book_no_search_result2),
@@ -56,23 +86,42 @@ fun SearchBookFilteredResult(
             )
         } else {
             LazyColumn(
-                verticalArrangement = Arrangement.Center
+                state = listState,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 itemsIndexed(bookList) { index, book ->
-                    CardBookList(
-                        title = book.title,
-                        author = book.author,
-                        publisher = book.publisher,
-                        imageUrl = book.imageUrl
-                    )
-                    if (index < bookList.size - 1) {
-                        Spacer(
-                            modifier = Modifier
-                                .padding(top = 12.dp, bottom = 12.dp)
-                                .fillMaxWidth()
-                                .height(1.dp)
-                                .background(colors.DarkGrey02)
+                    Column {
+                        CardBookList(
+                            title = book.title,
+                            author = book.author,
+                            publisher = book.publisher,
+                            imageUrl = book.imageUrl
                         )
+                        if (index < bookList.size - 1) {
+                            Spacer(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(1.dp)
+                                    .background(colors.DarkGrey02)
+                            )
+                        }
+                    }
+                }
+                
+                // 로딩 인디케이터
+                if (isLoading) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                color = colors.White
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
@@ -1,6 +1,7 @@
 package com.texthip.thip.ui.search.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,7 +39,8 @@ fun SearchBookFilteredResult(
     bookList: List<BookData>,
     isLoading: Boolean = false,
     hasMore: Boolean = true,
-    onLoadMore: () -> Unit = {}
+    onLoadMore: () -> Unit = {},
+    onBookClick: (BookData) -> Unit = {}
 ) {
     val listState = rememberLazyListState()
     
@@ -92,6 +94,7 @@ fun SearchBookFilteredResult(
                 itemsIndexed(bookList) { index, book ->
                     Column {
                         CardBookList(
+                            modifier = Modifier.clickable { onBookClick(book) },
                             title = book.title,
                             author = book.author,
                             publisher = book.publisher,

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
@@ -45,7 +45,7 @@ fun SearchBookFilteredResult(
     val listState = rememberLazyListState()
     
     // 무한 스크롤을 위한 로직
-    val shouldLoadMore by remember {
+    val shouldLoadMore by remember(hasMore, isLoading) {
         derivedStateOf {
             val layoutInfo = listState.layoutInfo
             val totalItemsCount = layoutInfo.totalItemsCount

--- a/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/component/SearchBookFilteredResult.kt
@@ -51,7 +51,7 @@ fun SearchBookFilteredResult(
             val totalItemsCount = layoutInfo.totalItemsCount
             val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
 
-            hasMore && !isLoading && lastVisibleItemIndex >= totalItemsCount - 3
+            hasMore && !isLoading && totalItemsCount > 0 && lastVisibleItemIndex >= totalItemsCount - 3
         }
     }
 
@@ -80,17 +80,10 @@ fun SearchBookFilteredResult(
                 .background(colors.DarkGrey02)
         )
 
-        if (bookList.isEmpty() && !isLoading) {
-            SearchEmptyResult(
-                mainText = stringResource(R.string.book_no_search_result1),
-                subText = stringResource(R.string.book_no_search_result2),
-                onRequestBook = { /*책 요청 처리*/ }
-            )
-        } else {
-            LazyColumn(
-                state = listState,
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
+        LazyColumn(
+            state = listState,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
                 itemsIndexed(bookList) { index, book ->
                     Column {
                         CardBookList(
@@ -127,12 +120,11 @@ fun SearchBookFilteredResult(
                         }
                     }
                 }
-            }
         }
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun PreviewBookFilteredSearchResult() {
     ThipTheme {
@@ -155,6 +147,17 @@ fun PreviewBookFilteredSearchResult() {
                     publisher = "사이언스북스"
                 )
             )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewBookFilteredSearchResultEmpty() {
+    ThipTheme {
+        SearchBookFilteredResult(
+            resultCount = 0,
+            bookList = emptyList()
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/mock/BookData.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/mock/BookData.kt
@@ -6,5 +6,6 @@ data class BookData(
     val title: String,
     val author: String = "",
     val publisher: String = "",
-    val imageUrl: String? = null
+    val imageUrl: String? = null,
+    val isbn: String = ""
 )

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookDetailScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookDetailScreen.kt
@@ -1,7 +1,7 @@
 package com.texthip.thip.ui.search.screen
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
+import coil.compose.AsyncImage
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,15 +16,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -37,7 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.R
-import com.texthip.thip.ui.search.mock.DetailBookData
+import com.texthip.thip.ui.search.viewmodel.BookDetailViewModel
 import com.texthip.thip.ui.common.buttons.ActionMediumButton
 import com.texthip.thip.ui.common.buttons.FilterButton
 import com.texthip.thip.ui.common.modal.InfoPopup
@@ -51,14 +54,16 @@ import kotlinx.coroutines.delay
 @Composable
 fun SearchBookDetailScreen(
     modifier: Modifier = Modifier,
-    book: DetailBookData,
+    isbn: String,
     feedList: List<String> = emptyList(),
     onLeftClick: () -> Unit = {},
     onRightClick: () -> Unit = {},
     onRecruitingGroupClick: () -> Unit = {},
     onBookMarkClick: (Boolean) -> Unit = {},
-    onWriteFeedClick: () -> Unit = {}
+    onWriteFeedClick: () -> Unit = {},
+    viewModel: BookDetailViewModel = hiltViewModel()
 ) {
+    val uiState by viewModel.uiState.collectAsState()
     var isAlarmVisible by remember { mutableStateOf(true) }
     var isIntroductionPopupVisible by remember { mutableStateOf(false) }
     var isBookmarked by remember { mutableStateOf(false) }
@@ -69,6 +74,11 @@ fun SearchBookDetailScreen(
         stringResource(R.string.search_filter_latest)
     )
 
+    // ISBN으로 책 상세 정보 로드
+    LaunchedEffect(isbn) {
+        viewModel.loadBookDetail(isbn)
+    }
+
     // 알림 5초간 노출
     LaunchedEffect(Unit) {
         isAlarmVisible = true
@@ -76,248 +86,279 @@ fun SearchBookDetailScreen(
         isAlarmVisible = false
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        // 메인 컨텐츠
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .then(
-                    if (isIntroductionPopupVisible) {
-                        Modifier.blur(4.dp)
-                    } else {
-                        Modifier
-                    }
+    when {
+        uiState.isLoading -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    color = colors.White
                 )
-        ) {
-            if (book.coverImageRes != null) {
-                Box(modifier = Modifier
-                    .height(420.dp)
-                    .fillMaxWidth()) {
-                    Image(
-                        painter = painterResource(book.coverImageRes),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .matchParentSize()
-                            .blur(4.dp),
-                        contentScale = ContentScale.Crop
-                    )
-                    Box(
-                        modifier = Modifier
-                            .matchParentSize()
-                            .background(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        Color.Transparent,
-                                        colors.Black.copy(alpha = 0.3f),
-                                        colors.Black.copy(alpha = 0.6f),
-                                        colors.Black.copy(alpha = 0.9f),
-                                        colors.Black
-                                    ),
-                                    startY = 0f,
-                                    endY = Float.POSITIVE_INFINITY
-                                )
-                            )
-                    )
-                }
             }
+        }
+        uiState.error != null -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = uiState.error!!,
+                    color = colors.White,
+                    style = typography.smalltitle_sb600_s16_h20
+                )
+            }
+        }
+        uiState.bookDetail != null -> {
+            val bookDetail = uiState.bookDetail!!
+            isBookmarked = bookDetail.isSaved
 
-            Column(modifier = Modifier.fillMaxSize()) {
-                AnimatedVisibility(visible = isAlarmVisible) {
-                    GradationTopAppBar(
-                        isImageVisible = true,
-                        count = book.participantsCount,
-                        onLeftClick = {},
-                        onRightClick = {}
-                    )
-                }
-                AnimatedVisibility(visible = !isAlarmVisible) {
-                    DefaultTopAppBar(
-                        isRightIconVisible = true,
-                        isTitleVisible = false,
-                        onLeftClick = onLeftClick,
-                        onRightClick = onRightClick
-                    )
-                }
-
-                // 상세 정보 영역
-                Column(
+            Box(modifier = modifier.fillMaxSize()) {
+                // 메인 컨텐츠
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp)
-                ) {
-                    Text(
-                        modifier = Modifier.padding(top = 40.dp),
-                        text = book.title,
-                        color = colors.White,
-                        style = typography.bigtitle_b700_s22
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    Text(
-                        text = stringResource(
-                            R.string.search_book_author,
-                            book.author,
-                            book.publisher
-                        ),
-                        color = colors.Grey,
-                        style = typography.menu_sb600_s12_h20
-                    )
-
-                    Column(
-                        modifier = Modifier
-                            .padding(top = 33.dp)
-                            .fillMaxWidth()
-                            .clickable { isIntroductionPopupVisible = true }
-                    ) {
-                        Text(
-                            text = stringResource(R.string.search_book_comment),
-                            color = colors.White,
-                            style = typography.menu_sb600_s14_h24,
-                        )
-                        Spacer(modifier = Modifier.height(5.dp))
-
-                        Text(
-                            text = book.description,
-                            color = colors.Grey,
-                            style = typography.copy_r400_s12_h20,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.height(40.dp))
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        ActionMediumButton(
-                            text = stringResource(
-                                R.string.search_recruiting_group_count,
-                                book.recruitingRoomCount
-                            ),
-                            contentColor = colors.Grey,
-                            backgroundColor = Color.Transparent,
-                            hasRightIcon = true,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .border(
-                                    width = 1.dp,
-                                    color = colors.Grey,
-                                    shape = RoundedCornerShape(12.dp)
-                                ),
-                            onClick = onRecruitingGroupClick,
-                        )
-                        Row {
-                            ActionMediumButton(
-                                text = stringResource(R.string.search_write_feed_comment),
-                                contentColor = colors.White,
-                                backgroundColor = colors.Purple,
-                                hasRightIcon = true,
-                                hasRightPlusIcon = true,
-                                modifier = Modifier.weight(1f),
-                                onClick = onWriteFeedClick
-                            )
-                            Box(
-                                modifier = modifier
-                                    .padding(start = 12.dp)
-                                    .size(44.dp)
-                                    .border(
-                                        width = 1.dp,
-                                        color = colors.Grey02,
-                                        shape = RoundedCornerShape(12.dp)
-                                    )
-                                    .background(
-                                        color = Color.Transparent,
-                                        shape = RoundedCornerShape(12.dp)
-                                    )
-                                    .clickable {
-                                        isBookmarked = !isBookmarked
-                                        onBookMarkClick(isBookmarked)
-                                    },
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Icon(
-                                    painter = painterResource(
-                                        if (isBookmarked)
-                                            R.drawable.ic_save_filled
-                                        else
-                                            R.drawable.ic_save
-                                    ),
-                                    contentDescription = null,
-                                    tint = Color.Unspecified,
-                                    modifier = Modifier.size(24.dp)
-                                )
+                        .fillMaxSize()
+                        .then(
+                            if (isIntroductionPopupVisible) {
+                                Modifier.blur(4.dp)
+                            } else {
+                                Modifier
                             }
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(44.dp))
-
-                    Text(
-                        text = stringResource(R.string.search_watch_feed),
-                        color = colors.Grey,
-                        style = typography.smalltitle_sb600_s18_h24,
-                        modifier = Modifier.padding(bottom = 33.dp)
-                    )
-
-                    // 피드 리스트
-                    Spacer(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(1.dp)
-                            .background(colors.DarkGrey02)
-                    )
-                    if (feedList.isEmpty()) {
+                        )
+                ) {
+                    // 실제 책 이미지 사용
+                    Box(modifier = Modifier
+                        .height(420.dp)
+                        .fillMaxWidth()) {
+                        AsyncImage(
+                            model = bookDetail.imageUrl,
+                            contentDescription = bookDetail.title,
+                            modifier = Modifier
+                                .matchParentSize()
+                                .blur(4.dp),
+                            contentScale = ContentScale.Crop,
+                            fallback = painterResource(R.drawable.img_book_cover_sample),
+                            error = painterResource(R.drawable.img_book_cover_sample)
+                        )
                         Box(
                             modifier = Modifier
-                                .fillMaxWidth()
-                                .weight(1f),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(
-                                    text = stringResource(R.string.search_no_feed_comment_1),
-                                    color = colors.White,
-                                    style = typography.smalltitle_sb600_s18_h24
+                                .matchParentSize()
+                                .background(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color.Transparent,
+                                            colors.Black.copy(alpha = 0.3f),
+                                            colors.Black.copy(alpha = 0.6f),
+                                            colors.Black.copy(alpha = 0.9f),
+                                            colors.Black
+                                        ),
+                                        startY = 0f,
+                                        endY = Float.POSITIVE_INFINITY
+                                    )
                                 )
-                                Spacer(modifier = Modifier.height(6.dp))
+                        )
+                    }
+
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        AnimatedVisibility(visible = isAlarmVisible) {
+                            GradationTopAppBar(
+                                isImageVisible = true,
+                                count = bookDetail.readCount,
+                                onLeftClick = onLeftClick,
+                                onRightClick = {}
+                            )
+                        }
+                        AnimatedVisibility(visible = !isAlarmVisible) {
+                            DefaultTopAppBar(
+                                isRightIconVisible = true,
+                                isTitleVisible = false,
+                                onLeftClick = onLeftClick,
+                                onRightClick = onRightClick
+                            )
+                        }
+
+                        // 상세 정보 영역
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp)
+                        ) {
+                            Text(
+                                modifier = Modifier.padding(top = 40.dp),
+                                text = bookDetail.title,
+                                color = colors.White,
+                                style = typography.bigtitle_b700_s22
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            Text(
+                                text = stringResource(
+                                    R.string.search_book_author,
+                                    bookDetail.authorName,
+                                    bookDetail.publisher
+                                ),
+                                color = colors.Grey,
+                                style = typography.menu_sb600_s12_h20
+                            )
+
+                            Column(
+                                modifier = Modifier
+                                    .padding(top = 33.dp)
+                                    .fillMaxWidth()
+                                    .clickable { isIntroductionPopupVisible = true }
+                            ) {
                                 Text(
-                                    text = stringResource(R.string.search_no_feed_comment_2),
-                                    color = colors.Grey01,
-                                    style = typography.feedcopy_r400_s14_h20
+                                    text = stringResource(R.string.search_book_comment),
+                                    color = colors.White,
+                                    style = typography.menu_sb600_s14_h24,
+                                )
+                                Spacer(modifier = Modifier.height(5.dp))
+
+                                Text(
+                                    text = bookDetail.description,
+                                    color = colors.Grey,
+                                    style = typography.copy_r400_s12_h20,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
+
+                            Spacer(modifier = Modifier.height(40.dp))
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                ActionMediumButton(
+                                    text = stringResource(
+                                        R.string.search_recruiting_group_count,
+                                        bookDetail.recruitingRoomCount
+                                    ),
+                                    contentColor = colors.Grey,
+                                    backgroundColor = Color.Transparent,
+                                    hasRightIcon = true,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .border(
+                                            width = 1.dp,
+                                            color = colors.Grey,
+                                            shape = RoundedCornerShape(12.dp)
+                                        ),
+                                    onClick = onRecruitingGroupClick,
+                                )
+                                Row {
+                                    ActionMediumButton(
+                                        text = stringResource(R.string.search_write_feed_comment),
+                                        contentColor = colors.White,
+                                        backgroundColor = colors.Purple,
+                                        hasRightIcon = true,
+                                        hasRightPlusIcon = true,
+                                        modifier = Modifier.weight(1f),
+                                        onClick = onWriteFeedClick
+                                    )
+                                    Box(
+                                        modifier = Modifier
+                                            .padding(start = 12.dp)
+                                            .size(44.dp)
+                                            .border(
+                                                width = 1.dp,
+                                                color = colors.Grey02,
+                                                shape = RoundedCornerShape(12.dp)
+                                            )
+                                            .background(
+                                                color = Color.Transparent,
+                                                shape = RoundedCornerShape(12.dp)
+                                            )
+                                            .clickable {
+                                                isBookmarked = !isBookmarked
+                                                onBookMarkClick(isBookmarked)
+                                            },
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(
+                                                if (isBookmarked)
+                                                    R.drawable.ic_save_filled
+                                                else
+                                                    R.drawable.ic_save
+                                            ),
+                                            contentDescription = null,
+                                            tint = Color.Unspecified,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    }
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(44.dp))
+
+                            Text(
+                                text = stringResource(R.string.search_watch_feed),
+                                color = colors.Grey,
+                                style = typography.smalltitle_sb600_s18_h24,
+                                modifier = Modifier.padding(bottom = 33.dp)
+                            )
+
+                            // 피드 리스트
+                            Spacer(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(1.dp)
+                                    .background(colors.DarkGrey02)
+                            )
+                            if (feedList.isEmpty()) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .weight(1f),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                        Text(
+                                            text = stringResource(R.string.search_no_feed_comment_1),
+                                            color = colors.White,
+                                            style = typography.smalltitle_sb600_s18_h24
+                                        )
+                                        Spacer(modifier = Modifier.height(6.dp))
+                                        Text(
+                                            text = stringResource(R.string.search_no_feed_comment_2),
+                                            color = colors.Grey01,
+                                            style = typography.feedcopy_r400_s14_h20
+                                        )
+                                    }
+                                }
+                            } else {
+                                // TODO: 피드 UI 구현 되면 수정
+                            }
                         }
-                    } else {
-                        // TODO: 피드 UI 구현 되면 수정
+                    }
+                }
+
+                FilterButton(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 462.dp, start = 20.dp, end = 20.dp),
+                    selectedOption = filterOptions[selectedFilterOption],
+                    options = filterOptions,
+                    onOptionSelected = { option ->
+                        selectedFilterOption = filterOptions.indexOf(option)
+                    }
+                )
+
+                if (isIntroductionPopupVisible) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(horizontal = 20.dp)
+                    ) {
+                        InfoPopup(
+                            title = stringResource(R.string.introduction),
+                            content = bookDetail.description,
+                            onDismiss = { isIntroductionPopupVisible = false }
+                        )
                     }
                 }
             }
-
-            FilterButton(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(top = 462.dp, start = 20.dp, end = 20.dp),
-                selectedOption = filterOptions[selectedFilterOption],
-                options = filterOptions,
-                onOptionSelected = { option ->
-                    selectedFilterOption = filterOptions.indexOf(option)
-                }
-            )
         }
-
-        if (isIntroductionPopupVisible) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(horizontal = 20.dp)
-            ) {
-                InfoPopup(
-                    title = stringResource(R.string.introduction),
-                    content = book.description,
-                    onDismiss = { isIntroductionPopupVisible = false }
-                )
-            }
-        }
+        else -> {}
     }
 }
 
@@ -326,17 +367,7 @@ fun SearchBookDetailScreen(
 fun PreviewBookDetailScreen() {
     ThipTheme {
         SearchBookDetailScreen(
-            book = DetailBookData(
-                title = "채식주의자",
-                author = "한강",
-                publisher = "창비",
-                description =
-                    "인터내셔널 북커상, 산클레멘테 문학상 수상작. 전세계가 주목한 인간의 역작을 다시 만나다.2016년 인터내셔널 북커상을 수상하며 한국문학의 입지를 한단계 확장시킨 한강의 명단소설 『채식주의자』. 15년 만에 새로운 장정과 판형으로 출간된다. 식물화로 건설해온 극단적이며 실재적인 상상력의 강렬한 결실로 고통과 구속의 피안에 존재하는 인간의 본성에 다가간 작품." +
-                            "인터내셔널 북커상, 산클레멘테 문학상 수상작. 전세계가 주목한 인간의 역작을 다시 만나다. \n\n2016년 인터내셔널 북커상을 수상하며 한국문학의 입지를 한단계 확장시킨 한강의 명단소설 『채식주의자』. 15년 만에 새로운 장정과 판형으로 출간된다. 식물화로 건설해온 극단적이며 실재적인 상상력의 강렬한 결실로 고통과 구속의 피안에 존재하는 인간의 본성에 다가간 작품.",
-                coverImageRes = R.drawable.img_book_cover_sample,
-                participantsCount = 210,
-                recruitingRoomCount = 4
-            ),
+            isbn = "9788954682152",
             feedList = emptyList()
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookDetailScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookDetailScreen.kt
@@ -269,8 +269,10 @@ fun SearchBookDetailScreen(
                                                 shape = RoundedCornerShape(12.dp)
                                             )
                                             .clickable {
-                                                isBookmarked = !isBookmarked
-                                                onBookMarkClick(isBookmarked)
+                                                val newBookmarkState = !isBookmarked
+                                                isBookmarked = newBookmarkState
+                                                viewModel.saveBook(isbn, newBookmarkState)
+                                                onBookMarkClick(newBookmarkState)
                                             },
                                         contentAlignment = Alignment.Center,
                                     ) {

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookDetailScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookDetailScreen.kt
@@ -59,7 +59,6 @@ fun SearchBookDetailScreen(
     onLeftClick: () -> Unit = {},
     onRightClick: () -> Unit = {},
     onRecruitingGroupClick: () -> Unit = {},
-    onBookMarkClick: (Boolean) -> Unit = {},
     onWriteFeedClick: () -> Unit = {},
     viewModel: BookDetailViewModel = hiltViewModel()
 ) {
@@ -272,7 +271,6 @@ fun SearchBookDetailScreen(
                                                 val newBookmarkState = !isBookmarked
                                                 isBookmarked = newBookmarkState
                                                 viewModel.saveBook(isbn, newBookmarkState)
-                                                onBookMarkClick(newBookmarkState)
                                             },
                                         contentAlignment = Alignment.Center,
                                     ) {

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
@@ -201,6 +201,7 @@ private fun SearchBookGroupScreenContent(
                                 snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
                                     .collect { lastVisibleIndex ->
                                         if (lastVisibleIndex != null && 
+                                            recruitingList.isNotEmpty() &&
                                             lastVisibleIndex >= recruitingList.size - 3 && 
                                             canLoadMore) {
                                             onLoadMore()

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
@@ -197,11 +197,12 @@ private fun SearchBookGroupScreenContent(
                             val listState = rememberLazyListState()
                             
                             // 무한 스크롤 로직
-                            LaunchedEffect(listState) {
+                            LaunchedEffect(listState, canLoadMore, isLoadingMore) {
                                 snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
                                     .collect { lastVisibleIndex ->
                                         if (lastVisibleIndex != null && 
                                             recruitingList.isNotEmpty() &&
+                                            !isLoadingMore &&
                                             lastVisibleIndex >= recruitingList.size - 3 && 
                                             canLoadMore) {
                                             onLoadMore()

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
@@ -39,6 +39,7 @@ import com.texthip.thip.ui.search.viewmodel.SearchBookGroupViewModel
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
+import com.texthip.thip.utils.rooms.DateUtils
 
 
 @Composable
@@ -79,12 +80,14 @@ fun SearchBookGroupScreen(
         }
         else -> {
             val recruitingList = uiState.recruitingRooms.map { item ->
+                val daysLeft = DateUtils.extractDaysFromDeadline(item.deadlineEndDate)
+
                 GroupCardItemRoomData(
                     id = item.roomId,
                     title = item.roomName,
                     participants = item.memberCount,
                     maxParticipants = item.recruitCount,
-                    endDate = item.deadlineEndDate.toIntOrNull() ?: 0,
+                    endDate = daysLeft,
                     imageUrl = item.bookImageUrl,
                     isRecruiting = true
                 )

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
@@ -13,215 +13,227 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.texthip.thip.R
 import com.texthip.thip.ui.common.cards.CardItemRoom
 import com.texthip.thip.ui.common.topappbar.DefaultTopAppBar
 import com.texthip.thip.ui.group.myroom.mock.GroupCardItemRoomData
+import com.texthip.thip.ui.search.viewmodel.SearchBookGroupViewModel
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
 
+
 @Composable
 fun SearchBookGroupScreen(
-    recruitingList: List<GroupCardItemRoomData>,
-    onCardClick: (GroupCardItemRoomData) -> Unit = {},
-    onCreateRoomClick: () -> Unit = {}
+    isbn: String,
+    onLeftClick: () -> Unit = {},
+    onCardClick: (Int) -> Unit = {},
+    onCreateRoomClick: () -> Unit = {},
+    viewModel: SearchBookGroupViewModel = hiltViewModel()
 ) {
-    Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Column(
-            Modifier.fillMaxSize()
-        ) {
-            DefaultTopAppBar(
-                title = stringResource(R.string.group_recruiting_title),
-                onLeftClick = {},
-            )
+    val uiState by viewModel.uiState.collectAsState()
 
-            Column(
-                Modifier
-                    .background(colors.Black)
-                    .fillMaxSize()
-                    .padding(horizontal = 20.dp)
-                    .padding(top = 16.dp)
+    LaunchedEffect(isbn) {
+        viewModel.loadRecruitingRooms(isbn)
+    }
+    when {
+        uiState.isLoading -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stringResource(R.string.group_searched_room_size, recruitingList.size),
-                        color = colors.Grey,
-                        style = typography.menu_m500_s14_h24
-                    )
-                }
-                Spacer(
-                    modifier = Modifier
-                        .padding(top = 4.dp, bottom = 20.dp)
-                        .fillMaxWidth()
-                        .height(1.dp)
-                        .background(colors.DarkGrey02)
+                CircularProgressIndicator(
+                    color = colors.White
                 )
+            }
+        }
+        uiState.error != null -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = uiState.error!!,
+                    color = colors.White,
+                    style = typography.smalltitle_sb600_s16_h20
+                )
+            }
+        }
+        else -> {
+            val recruitingList = uiState.recruitingRooms.map { item ->
+                GroupCardItemRoomData(
+                    id = item.roomId,
+                    title = item.roomName,
+                    participants = item.memberCount,
+                    maxParticipants = item.recruitCount,
+                    endDate = item.deadlineEndDate.toIntOrNull() ?: 0,
+                    imageUrl = item.bookImageUrl,
+                    isRecruiting = true
+                )
+            }
 
-                if (recruitingList.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                // 기존 콘텐츠 Column
+                Column(
+                    Modifier.fillMaxSize()
+                ) {
+                    DefaultTopAppBar(
+                        title = stringResource(R.string.group_recruiting_title),
+                        onLeftClick = onLeftClick,
+                    )
+
                     Column(
-                        modifier = Modifier
+                        Modifier
                             .fillMaxSize()
-                            .padding(bottom = 50.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
+                            .padding(horizontal = 20.dp)
+                            .padding(top = 16.dp)
                     ) {
-                        Text(
-                            text = stringResource(R.string.book_recruiting_empty_message),
-                            color = colors.White,
-                            style = typography.smalltitle_sb600_s18_h24,
-                            textAlign = TextAlign.Center
-                        )
-                        Text(
-                            text = stringResource(R.string.book_recruiting_empty_sub_message),
-                            color = colors.Grey,
-                            style = typography.feedcopy_r400_s14_h20,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(top = 8.dp)
-                        )
-                    }
-                } else {
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(20.dp),
-                        contentPadding = PaddingValues(bottom = 70.dp),
-                        modifier = Modifier.fillMaxSize()
-                    ) {
-                        items(recruitingList) { item ->
-                            CardItemRoom(
-                                title = item.title,
-                                participants = item.participants,
-                                maxParticipants = item.maxParticipants,
-                                isRecruiting = item.isRecruiting,
-                                endDate = item.endDate,
-                                imageUrl = item.imageUrl,
-                                onClick = { onCardClick(item) }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    R.string.group_searched_room_size,
+                                    uiState.totalCount
+                                ),
+                                color = colors.Grey,
+                                style = typography.menu_m500_s14_h24
                             )
+                        }
+                        Spacer(
+                            modifier = Modifier
+                                .padding(top = 4.dp, bottom = 20.dp)
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(colors.DarkGrey02)
+                        )
+
+                        if (recruitingList.isEmpty()) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(bottom = 50.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.book_recruiting_empty_message),
+                                    color = colors.White,
+                                    style = typography.smalltitle_sb600_s18_h24,
+                                    textAlign = TextAlign.Center
+                                )
+                                Text(
+                                    text = stringResource(R.string.book_recruiting_empty_sub_message),
+                                    color = colors.Grey,
+                                    style = typography.feedcopy_r400_s14_h20,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(top = 8.dp)
+                                )
+                            }
+                        } else {
+                            val listState = rememberLazyListState()
+                            
+                            // 무한 스크롤 로직
+                            LaunchedEffect(listState) {
+                                snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+                                    .collect { lastVisibleIndex ->
+                                        if (lastVisibleIndex != null && 
+                                            lastVisibleIndex >= recruitingList.size - 3 && 
+                                            uiState.canLoadMore) {
+                                            viewModel.loadMoreRooms()
+                                        }
+                                    }
+                            }
+                            
+                            LazyColumn(
+                                state = listState,
+                                verticalArrangement = Arrangement.spacedBy(20.dp),
+                                contentPadding = PaddingValues(bottom = 80.dp),
+                                modifier = Modifier.fillMaxSize()
+                            ) {
+                                items(recruitingList) { item ->
+                                    CardItemRoom(
+                                        title = item.title,
+                                        participants = item.participants,
+                                        maxParticipants = item.maxParticipants,
+                                        isRecruiting = item.isRecruiting,
+                                        endDate = item.endDate,
+                                        imageUrl = item.imageUrl,
+                                        onClick = { onCardClick(item.id) }
+                                    )
+                                }
+                                
+                                // 로딩 인디케이터
+                                if (uiState.isLoadingMore) {
+                                    item {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            CircularProgressIndicator(
+                                                color = colors.White
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
 
-        // 하단 버튼
-        Button(
-            colors = ButtonDefaults.buttonColors(
-                containerColor = colors.Purple
-            ),
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .height(50.dp),
-            shape = RoundedCornerShape(0.dp),
-            onClick = onCreateRoomClick
-        ) {
-            Text(
-                text = stringResource(R.string.group_recruiting_create_button),
-                style = typography.smalltitle_sb600_s18_h24,
-                color = colors.White
-            )
+                Button(
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colors.Purple
+                    ),
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter) // Box의 하단 중앙에 정렬
+                        .fillMaxWidth()
+                        .height(50.dp),
+                    shape = RoundedCornerShape(0.dp),
+                    onClick = onCreateRoomClick
+                ) {
+                    Text(
+                        text = stringResource(R.string.group_recruiting_create_button),
+                        style = typography.smalltitle_sb600_s18_h24,
+                        color = colors.White
+                    )
+                }
+            }
         }
     }
 }
+
 
 @Preview()
 @Composable
 fun GroupRecruitingScreenPreview() {
     ThipTheme {
-        val dataList = listOf(
-            GroupCardItemRoomData(
-                id = 1,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 2,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 3,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 4,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 5,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 6,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 7,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            ),
-            GroupCardItemRoomData(
-                id = 8,
-                title = "모임방 이름입니다. 모임방...",
-                participants = 22,
-                maxParticipants = 30,
-                endDate = 3,
-                isRecruiting = true,
-            )
-        )
-
         SearchBookGroupScreen(
-            recruitingList = dataList
-        )
-    }
-}
-
-@Preview()
-@Composable
-fun GroupRecruitingScreenEmptyPreview() {
-    ThipTheme {
-        SearchBookGroupScreen(
-            recruitingList = emptyList()
+            isbn = "9788954682152"
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
@@ -55,10 +55,55 @@ fun SearchBookGroupScreen(
     LaunchedEffect(isbn) {
         viewModel.loadRecruitingRooms(isbn)
     }
+
+    val recruitingList = uiState.recruitingRooms.map { item ->
+        val daysLeft = DateUtils.extractDaysFromDeadline(item.deadlineEndDate)
+
+        GroupCardItemRoomData(
+            id = item.roomId,
+            title = item.roomName,
+            participants = item.memberCount,
+            maxParticipants = item.recruitCount,
+            endDate = daysLeft,
+            imageUrl = item.bookImageUrl,
+            isRecruiting = true
+        )
+    }
+
+    SearchBookGroupScreenContent(
+        isLoading = uiState.isLoading,
+        error = uiState.error,
+        recruitingList = recruitingList,
+        totalCount = uiState.totalCount,
+        isLoadingMore = uiState.isLoadingMore,
+        canLoadMore = uiState.canLoadMore,
+        onLeftClick = onLeftClick,
+        onCardClick = onCardClick,
+        onCreateRoomClick = onCreateRoomClick,
+        onLoadMore = {
+            viewModel.loadMoreRooms()
+        }
+    )
+}
+
+@Composable
+private fun SearchBookGroupScreenContent(
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    error: String? = null,
+    recruitingList: List<GroupCardItemRoomData> = emptyList(),
+    totalCount: Int = 0,
+    isLoadingMore: Boolean = false,
+    canLoadMore: Boolean = true,
+    onLeftClick: () -> Unit = {},
+    onCardClick: (Int) -> Unit = {},
+    onCreateRoomClick: () -> Unit = {},
+    onLoadMore: () -> Unit = {}
+) {
     when {
-        uiState.isLoading -> {
+        isLoading -> {
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier = modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator(
@@ -66,36 +111,21 @@ fun SearchBookGroupScreen(
                 )
             }
         }
-        uiState.error != null -> {
+        error != null -> {
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier = modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = uiState.error!!,
+                    text = error,
                     color = colors.White,
                     style = typography.smalltitle_sb600_s16_h20
                 )
             }
         }
         else -> {
-            val recruitingList = uiState.recruitingRooms.map { item ->
-                val daysLeft = DateUtils.extractDaysFromDeadline(item.deadlineEndDate)
-
-                GroupCardItemRoomData(
-                    id = item.roomId,
-                    title = item.roomName,
-                    participants = item.memberCount,
-                    maxParticipants = item.recruitCount,
-                    endDate = daysLeft,
-                    imageUrl = item.bookImageUrl,
-                    isRecruiting = true
-                )
-            }
-
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
+                modifier = modifier.fillMaxSize()
             ) {
                 // 기존 콘텐츠 Column
                 Column(
@@ -119,7 +149,7 @@ fun SearchBookGroupScreen(
                             Text(
                                 text = stringResource(
                                     R.string.group_searched_room_size,
-                                    uiState.totalCount
+                                    totalCount
                                 ),
                                 color = colors.Grey,
                                 style = typography.menu_m500_s14_h24
@@ -164,8 +194,8 @@ fun SearchBookGroupScreen(
                                     .collect { lastVisibleIndex ->
                                         if (lastVisibleIndex != null && 
                                             lastVisibleIndex >= recruitingList.size - 3 && 
-                                            uiState.canLoadMore) {
-                                            viewModel.loadMoreRooms()
+                                            canLoadMore) {
+                                            onLoadMore()
                                         }
                                     }
                             }
@@ -189,7 +219,7 @@ fun SearchBookGroupScreen(
                                 }
                                 
                                 // 로딩 인디케이터
-                                if (uiState.isLoadingMore) {
+                                if (isLoadingMore) {
                                     item {
                                         Box(
                                             modifier = Modifier
@@ -230,13 +260,90 @@ fun SearchBookGroupScreen(
     }
 }
 
+// Preview용 Mock 데이터
+private val mockRecruitingList = listOf(
+    GroupCardItemRoomData(
+        id = 1,
+        title = "데미안 함께 읽기 📚",
+        participants = 8,
+        maxParticipants = 12,
+        isRecruiting = true,
+        endDate = 3,
+        imageUrl = "https://example.com/demian.jpg",
+        isSecret = false
+    ),
+    GroupCardItemRoomData(
+        id = 2,
+        title = "헤르만 헤세 작품 토론방",
+        participants = 15,
+        maxParticipants = 20,
+        isRecruiting = true,
+        endDate = 7,
+        imageUrl = "https://example.com/demian.jpg",
+        isSecret = true
+    ),
+    GroupCardItemRoomData(
+        id = 3,
+        title = "클래식 문학 읽기 모임",
+        participants = 5,
+        maxParticipants = 10,
+        isRecruiting = true,
+        endDate = 1,
+        imageUrl = "https://example.com/demian.jpg",
+        isSecret = false
+    )
+)
 
-@Preview()
+@Preview(showBackground = true)
 @Composable
-fun GroupRecruitingScreenPreview() {
+fun SearchBookGroupScreenContentPreview() {
     ThipTheme {
-        SearchBookGroupScreen(
-            isbn = "9788954682152"
+        SearchBookGroupScreenContent(
+            recruitingList = mockRecruitingList,
+            totalCount = 8
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SearchBookGroupScreenContentEmptyPreview() {
+    ThipTheme {
+        SearchBookGroupScreenContent(
+            recruitingList = emptyList(),
+            totalCount = 0
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SearchBookGroupScreenContentLoadingMorePreview() {
+    ThipTheme {
+        SearchBookGroupScreenContent(
+            recruitingList = mockRecruitingList,
+            totalCount = 15,
+            isLoadingMore = true,
+            canLoadMore = true
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SearchBookGroupScreenContentLoadingPreview() {
+    ThipTheme {
+        SearchBookGroupScreenContent(
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SearchBookGroupScreenContentErrorPreview() {
+    ThipTheme {
+        SearchBookGroupScreenContent(
+            error = "모집 중인 그룹을 불러오는데 실패했습니다."
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookGroupScreen.kt
@@ -47,7 +47,7 @@ fun SearchBookGroupScreen(
     isbn: String,
     onLeftClick: () -> Unit = {},
     onCardClick: (Int) -> Unit = {},
-    onCreateRoomClick: () -> Unit = {},
+    onCreateRoomClick: (isbn: String, title: String, imageUrl: String, author: String) -> Unit = { _, _, _, _ -> },
     viewModel: SearchBookGroupViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -77,6 +77,10 @@ fun SearchBookGroupScreen(
         totalCount = uiState.totalCount,
         isLoadingMore = uiState.isLoadingMore,
         canLoadMore = uiState.canLoadMore,
+        isbn = isbn,
+        bookTitle = uiState.bookDetail?.title ?: "",
+        bookImageUrl = uiState.bookDetail?.imageUrl ?: "",
+        bookAuthor = uiState.bookDetail?.authorName ?: "",
         onLeftClick = onLeftClick,
         onCardClick = onCardClick,
         onCreateRoomClick = onCreateRoomClick,
@@ -95,9 +99,13 @@ private fun SearchBookGroupScreenContent(
     totalCount: Int = 0,
     isLoadingMore: Boolean = false,
     canLoadMore: Boolean = true,
+    isbn: String = "",
+    bookTitle: String = "",
+    bookImageUrl: String = "",
+    bookAuthor: String = "",
     onLeftClick: () -> Unit = {},
     onCardClick: (Int) -> Unit = {},
-    onCreateRoomClick: () -> Unit = {},
+    onCreateRoomClick: (isbn: String, title: String, imageUrl: String, author: String) -> Unit = { _, _, _, _ -> },
     onLoadMore: () -> Unit = {}
 ) {
     when {
@@ -247,7 +255,9 @@ private fun SearchBookGroupScreenContent(
                         .fillMaxWidth()
                         .height(50.dp),
                     shape = RoundedCornerShape(0.dp),
-                    onClick = onCreateRoomClick
+                    onClick = { 
+                        onCreateRoomClick(isbn, bookTitle, bookImageUrl, bookAuthor)
+                    }
                 ) {
                     Text(
                         text = stringResource(R.string.group_recruiting_create_button),

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
@@ -43,7 +43,6 @@ import kotlinx.serialization.builtins.serializer
 fun SearchBookScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController? = null,
-    popularBooks: List<BookData> = emptyList(),
     viewModel: SearchBookViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -119,7 +118,14 @@ fun SearchBookScreen(
                     uiState.searchQuery.isBlank() -> {
                         SearchRecentBook(
                             recentSearches = recentSearches,
-                            popularBooks = popularBooks,
+                            popularBooks = uiState.popularBooks.map { item ->
+                                BookData(
+                                    title = item.title,
+                                    author = "",
+                                    publisher = "",
+                                    imageUrl = item.imageUrl
+                                )
+                            },
                             popularBookDate = "01.12", // TODO: 서버로 날짜를 받아 오게 수정
                             onSearchClick = { keyword ->
                                 viewModel.updateSearchQuery(keyword)
@@ -193,15 +199,7 @@ fun SearchBookScreen(
 @Composable
 fun PreviewBookSearchScreen_Default() {
     ThipTheme {
-        SearchBookScreen(
-            popularBooks = listOf(
-                BookData(title = "단 한번의 삶", author = "리처드 도킨스", publisher = "을유문화사", imageUrl = null),
-                BookData(title = "사랑", author = "마틴 셀리그만", publisher = "물푸레", imageUrl = null),
-                BookData(title = "호모 사피엔스", author = "빅터 프랭클", publisher = "청림출판", imageUrl = null),
-                BookData(title = "코스모스 실버", author = "칼 융", publisher = "문학과지성사", imageUrl = null),
-                BookData(title = "오만과 편견", author = "에릭 프롬", publisher = "까치글방", imageUrl = null),
-            )
-        )
+        SearchBookScreen()
     }
 }
 
@@ -209,8 +207,6 @@ fun PreviewBookSearchScreen_Default() {
 @Composable
 fun PreviewBookSearchScreen_EmptyPopular() {
     ThipTheme {
-        SearchBookScreen(
-            popularBooks = emptyList()
-        )
+        SearchBookScreen()
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
@@ -35,6 +35,7 @@ import com.texthip.thip.ui.search.component.SearchEmptyResult
 import com.texthip.thip.ui.search.component.SearchRecentBook
 import com.texthip.thip.ui.search.mock.BookData
 import com.texthip.thip.ui.search.viewmodel.SearchBookViewModel
+import com.texthip.thip.ui.search.viewmodel.SearchMode
 import com.texthip.thip.ui.theme.ThipTheme
 
 @Composable
@@ -94,9 +95,8 @@ fun SearchBookScreen(
                 )
                 Spacer(modifier = Modifier.height(16.dp))
 
-                when {
-                    // 1. 검색어가 없는 상태 - 최근 검색어와 인기 책 표시
-                    uiState.searchQuery.isBlank() -> {
+                when (uiState.searchMode) {
+                    SearchMode.Initial -> {
                         SearchRecentBook(
                             recentSearches = uiState.recentSearches.map { it.searchTerm },
                             popularBooks = uiState.popularBooks.map { item ->
@@ -114,7 +114,6 @@ fun SearchBookScreen(
                                 viewModel.onSearchButtonClick()
                             },
                             onRemove = { keyword ->
-                                // 서버에서 해당 검색어를 찾아서 삭제
                                 val recentSearchItem = uiState.recentSearches.find { it.searchTerm == keyword }
                                 recentSearchItem?.let {
                                     viewModel.deleteRecentSearch(it.recentSearchId)
@@ -126,60 +125,65 @@ fun SearchBookScreen(
                         )
                     }
 
-                    // 2. 검색 완료 상태 - 전체 검색 결과 표시 (무한 스크롤 포함)
-                    uiState.isSearchCompleted -> {
-                        SearchBookFilteredResult(
-                            resultCount = uiState.totalElements,
-                            bookList = uiState.searchResults.map { item ->
-                                BookData(
-                                    title = item.title,
-                                    author = item.authorName,
-                                    publisher = item.publisher,
-                                    imageUrl = item.imageUrl,
-                                    isbn = item.isbn
-                                )
-                            },
-                            isLoading = uiState.isSearching || uiState.isLoadingMore,
-                            hasMore = uiState.canLoadMore,
-                            onLoadMore = {
-                                viewModel.loadMoreBooks()
-                            },
-                            onBookClick = { book ->
-                                onBookClick(book.isbn)
-                            }
-                        )
+                    SearchMode.LiveSearch -> {
+                        if (uiState.hasResults) {
+                            SearchActiveField(
+                                bookList = uiState.searchResults.map { item ->
+                                    BookData(
+                                        title = item.title,
+                                        author = item.authorName,
+                                        publisher = item.publisher,
+                                        imageUrl = item.imageUrl,
+                                        isbn = item.isbn
+                                    )
+                                },
+                                isLoading = uiState.isSearching || uiState.isLoadingMore,
+                                hasMore = uiState.canLoadMore,
+                                onLoadMore = {
+                                    viewModel.loadMoreBooks()
+                                },
+                                onBookClick = { book ->
+                                    onBookClick(book.isbn)
+                                }
+                            )
+                        } else if (uiState.showEmptyState) {
+                            SearchEmptyResult(
+                                mainText = stringResource(R.string.book_no_search_result1),
+                                subText = stringResource(R.string.book_no_search_result2),
+                                onRequestBook = { /*책 요청 처리*/ }
+                            )
+                        }
                     }
 
-                    // 3. Live search 결과가 있는 상태 - SearchActiveField 표시 (무한 스크롤 포함)
-                    uiState.hasLiveResults -> {
-                        SearchActiveField(
-                            bookList = uiState.liveSearchResults.map { item ->
-                                BookData(
-                                    title = item.title,
-                                    author = item.authorName,
-                                    publisher = item.publisher,
-                                    imageUrl = item.imageUrl,
-                                    isbn = item.isbn
-                                )
-                            },
-                            isLoading = uiState.isLiveSearching || uiState.isLiveLoadingMore,
-                            hasMore = uiState.canLiveLoadMore,
-                            onLoadMore = {
-                                viewModel.loadMoreLiveSearchResults()
-                            },
-                            onBookClick = { book ->
-                                onBookClick(book.isbn)
-                            }
-                        )
-                    }
-
-                    // 4. 검색어는 있지만 결과가 없는 상태 - Empty 표시
-                    uiState.showEmptyState -> {
-                        SearchEmptyResult(
-                            mainText = stringResource(R.string.book_no_search_result1),
-                            subText = stringResource(R.string.book_no_search_result2),
-                            onRequestBook = { /*책 요청 처리*/ }
-                        )
+                    SearchMode.CompleteSearch -> {
+                        if (uiState.hasResults) {
+                            SearchBookFilteredResult(
+                                resultCount = uiState.totalElements,
+                                bookList = uiState.searchResults.map { item ->
+                                    BookData(
+                                        title = item.title,
+                                        author = item.authorName,
+                                        publisher = item.publisher,
+                                        imageUrl = item.imageUrl,
+                                        isbn = item.isbn
+                                    )
+                                },
+                                isLoading = uiState.isSearching || uiState.isLoadingMore,
+                                hasMore = uiState.canLoadMore,
+                                onLoadMore = {
+                                    viewModel.loadMoreBooks()
+                                },
+                                onBookClick = { book ->
+                                    onBookClick(book.isbn)
+                                }
+                            )
+                        } else if (uiState.showEmptyState) {
+                            SearchEmptyResult(
+                                mainText = stringResource(R.string.book_no_search_result1),
+                                subText = stringResource(R.string.book_no_search_result2),
+                                onRequestBook = { /*책 요청 처리*/ }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
@@ -23,6 +23,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import com.texthip.thip.R
 import com.texthip.thip.ui.common.forms.SearchBookTextField
 import com.texthip.thip.ui.common.topappbar.LeftNameTopAppBar
@@ -105,7 +108,7 @@ fun SearchBookScreen(
                                     isbn = item.isbn
                                 )
                             },
-                            popularBookDate = "01.12", // TODO: 서버로 날짜를 받아 오게 수정
+                            popularBookDate = SimpleDateFormat("MM.dd", Locale.getDefault()).format(Date()),
                             onSearchClick = { keyword ->
                                 viewModel.updateSearchQuery(keyword)
                                 viewModel.onSearchButtonClick()

--- a/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/screen/SearchBookScreen.kt
@@ -42,7 +42,8 @@ import com.texthip.thip.ui.theme.ThipTheme
 fun SearchBookScreen(
     modifier: Modifier = Modifier,
     viewModel: SearchBookViewModel = hiltViewModel(),
-    onBookClick: (String) -> Unit = {}
+    onBookClick: (String) -> Unit = {},
+    onRequestBook: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val focusRequester = remember { FocusRequester() }
@@ -150,7 +151,7 @@ fun SearchBookScreen(
                             SearchEmptyResult(
                                 mainText = stringResource(R.string.book_no_search_result1),
                                 subText = stringResource(R.string.book_no_search_result2),
-                                onRequestBook = { /*책 요청 처리*/ }
+                                onRequestBook = onRequestBook
                             )
                         }
                     }
@@ -181,7 +182,7 @@ fun SearchBookScreen(
                             SearchEmptyResult(
                                 mainText = stringResource(R.string.book_no_search_result1),
                                 subText = stringResource(R.string.book_no_search_result2),
-                                onRequestBook = { /*책 요청 처리*/ }
+                                onRequestBook = onRequestBook
                             )
                         }
                     }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/BookDetailViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/BookDetailViewModel.kt
@@ -1,0 +1,48 @@
+package com.texthip.thip.ui.search.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.texthip.thip.data.model.book.response.BookDetailResponse
+import com.texthip.thip.data.repository.BookRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BookDetailViewModel @Inject constructor(
+    private val bookRepository: BookRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BookDetailUiState())
+    val uiState: StateFlow<BookDetailUiState> = _uiState.asStateFlow()
+
+    fun loadBookDetail(isbn: String) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            
+            bookRepository.getBookDetail(isbn)
+                .onSuccess { bookDetail ->
+                    _uiState.value = _uiState.value.copy(
+                        bookDetail = bookDetail,
+                        isLoading = false,
+                        error = null
+                    )
+                }
+                .onFailure { exception ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        error = exception.message ?: "책 정보를 불러오는데 실패했습니다."
+                    )
+                }
+        }
+    }
+}
+
+data class BookDetailUiState(
+    val bookDetail: BookDetailResponse? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/BookDetailViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/BookDetailViewModel.kt
@@ -39,10 +39,36 @@ class BookDetailViewModel @Inject constructor(
                 }
         }
     }
+
+    fun saveBook(isbn: String, type: Boolean) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, error = null)
+            
+            bookRepository.saveBook(isbn, type)
+                .onSuccess { saveResponse ->
+                    saveResponse?.let {
+                        // 책 상세 정보의 isSaved 상태 업데이트
+                        val updatedBookDetail = _uiState.value.bookDetail?.copy(isSaved = it.isSaved)
+                        _uiState.value = _uiState.value.copy(
+                            bookDetail = updatedBookDetail,
+                            isSaving = false,
+                            error = null
+                        )
+                    }
+                }
+                .onFailure { exception ->
+                    _uiState.value = _uiState.value.copy(
+                        isSaving = false,
+                        error = exception.message ?: "책 저장에 실패했습니다."
+                    )
+                }
+        }
+    }
 }
 
 data class BookDetailUiState(
     val bookDetail: BookDetailResponse? = null,
     val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
     val error: String? = null
 )

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.ui.search.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.RecruitingRoomItem
 import com.texthip.thip.data.repository.BookRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,11 +33,24 @@ class SearchBookGroupViewModel @Inject constructor(
                 recruitingRooms = emptyList(),
                 nextCursor = null,
                 hasMore = true,
-                totalCount = 0
+                totalCount = 0,
+                bookDetail = null
             )
             
+            // 책 정보와 모집중인 방 정보 동시 로드
+            loadBookDetail(isbn)
             loadRooms(isbn, null)
         }
+    }
+
+    private suspend fun loadBookDetail(isbn: String) {
+        bookRepository.getBookDetail(isbn)
+            .onSuccess { bookDetail ->
+                _uiState.value = _uiState.value.copy(bookDetail = bookDetail)
+            }
+            .onFailure { 
+                // 책 정보 로드 실패는 무시 (방 정보가 더 중요)
+            }
     }
 
     fun loadMoreRooms() {
@@ -94,7 +108,8 @@ data class SearchBookGroupUiState(
     val hasMore: Boolean = true,
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val bookDetail: BookDetailResponse? = null
 ) {
     val canLoadMore: Boolean get() = hasMore && !isLoading && !isLoadingMore
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
@@ -1,0 +1,100 @@
+package com.texthip.thip.ui.search.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.texthip.thip.data.model.book.response.RecruitingRoomItem
+import com.texthip.thip.data.repository.BookRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchBookGroupViewModel @Inject constructor(
+    private val bookRepository: BookRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SearchBookGroupUiState())
+    val uiState: StateFlow<SearchBookGroupUiState> = _uiState.asStateFlow()
+    
+    private var loadMoreJob: Job? = null
+    private var currentIsbn: String = ""
+
+    fun loadRecruitingRooms(isbn: String) {
+        currentIsbn = isbn
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isLoading = true, 
+                error = null,
+                recruitingRooms = emptyList(),
+                nextCursor = null,
+                hasMore = true,
+                totalCount = 0
+            )
+            
+            loadRooms(isbn, null)
+        }
+    }
+
+    fun loadMoreRooms() {
+        val currentState = _uiState.value
+        if (currentState.hasMore && !currentState.isLoading && !currentState.isLoadingMore && currentIsbn.isNotBlank()) {
+            loadMoreJob?.cancel()
+            loadMoreJob = viewModelScope.launch {
+                _uiState.value = _uiState.value.copy(isLoadingMore = true)
+                loadRooms(currentIsbn, currentState.nextCursor)
+            }
+        }
+    }
+
+    private suspend fun loadRooms(isbn: String, cursor: String?) {
+        bookRepository.getRecruitingRooms(isbn, cursor)
+            .onSuccess { response ->
+                response?.let { recruitingRoomsResponse ->
+                    val currentRooms = if (cursor == null) emptyList() else _uiState.value.recruitingRooms
+                    _uiState.value = _uiState.value.copy(
+                        recruitingRooms = currentRooms + recruitingRoomsResponse.recruitingRoomList,
+                        totalCount = recruitingRoomsResponse.totalRoomCount,
+                        nextCursor = recruitingRoomsResponse.nextCursor,
+                        hasMore = !recruitingRoomsResponse.isLast,
+                        isLoading = false,
+                        isLoadingMore = false,
+                        error = null
+                    )
+                } ?: run {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        isLoadingMore = false,
+                        error = if (cursor == null) "모집중인 방 정보를 찾을 수 없습니다." else null
+                    )
+                }
+            }
+            .onFailure { exception ->
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = exception.message ?: "모집중인 방을 불러오는데 실패했습니다."
+                )
+            }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        loadMoreJob?.cancel()
+    }
+}
+
+data class SearchBookGroupUiState(
+    val recruitingRooms: List<RecruitingRoomItem> = emptyList(),
+    val totalCount: Int = 0,
+    val nextCursor: String? = null,
+    val hasMore: Boolean = true,
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val error: String? = null
+) {
+    val canLoadMore: Boolean get() = hasMore && !isLoading && !isLoadingMore
+}

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
@@ -82,6 +82,7 @@ class SearchBookGroupViewModel @Inject constructor(
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         isLoadingMore = false,
+                        hasMore = false, // null 응답 시 더 이상 로드할 수 없음을 명시
                         error = if (cursor == null) "모집중인 방 정보를 찾을 수 없습니다." else null
                     )
                 }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookGroupViewModel.kt
@@ -25,6 +25,7 @@ class SearchBookGroupViewModel @Inject constructor(
     private var currentIsbn: String = ""
 
     fun loadRecruitingRooms(isbn: String) {
+        loadMoreJob?.cancel() // 신규 검색 시 이전 로드 작업 취소
         currentIsbn = isbn
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(
@@ -48,9 +49,7 @@ class SearchBookGroupViewModel @Inject constructor(
             .onSuccess { bookDetail ->
                 _uiState.value = _uiState.value.copy(bookDetail = bookDetail)
             }
-            .onFailure { 
-                // 책 정보 로드 실패는 무시 (방 정보가 더 중요)
-            }
+            .onFailure { }
     }
 
     fun loadMoreRooms() {

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
@@ -1,0 +1,32 @@
+package com.texthip.thip.ui.search.viewmodel
+
+import com.texthip.thip.data.model.book.response.BookSearchItem
+
+data class SearchBookUiState(
+    val searchQuery: String = "",
+    val liveSearchResults: List<BookSearchItem> = emptyList(), // Live search 결과 (검색어 입력 시)
+    val searchResults: List<BookSearchItem> = emptyList(), // 완료된 검색 결과 (검색 버튼 클릭 시)
+    val isLiveSearching: Boolean = false, // Live search 로딩 상태
+    val isSearching: Boolean = false, // 완료된 검색 로딩 상태
+    val isLoadingMore: Boolean = false,
+    val isLiveLoadingMore: Boolean = false, // Live search 무한 스크롤 로딩
+    val hasMorePages: Boolean = true,
+    val liveHasMorePages: Boolean = true, // Live search 페이징 정보
+    val isFirstPage: Boolean = true,
+    val currentPage: Int = 1,
+    val liveCurrentPage: Int = 1, // Live search 현재 페이지
+    val totalPages: Int = 0,
+    val liveTotalPages: Int = 0, // Live search 총 페이지
+    val totalElements: Int = 0,
+    val liveTotalElements: Int = 0, // Live search 총 요소
+    val isSearchCompleted: Boolean = false, // 검색 버튼을 눌러서 완료된 검색인지
+    val error: String? = null,
+    val showToast: Boolean = false,
+    val toastMessage: String = ""
+) {
+    val hasLiveResults: Boolean get() = liveSearchResults.isNotEmpty()
+    val hasSearchResults: Boolean get() = searchResults.isNotEmpty() && isSearchCompleted
+    val canLoadMore: Boolean get() = hasMorePages && !isSearching && !isLoadingMore && isSearchCompleted
+    val canLiveLoadMore: Boolean get() = liveHasMorePages && !isLiveSearching && !isLiveLoadingMore && !isSearchCompleted
+    val showEmptyState: Boolean get() = searchQuery.isNotBlank() && liveSearchResults.isEmpty() && !isLiveSearching && !isSearchCompleted
+}

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
@@ -2,15 +2,18 @@ package com.texthip.thip.ui.search.viewmodel
 
 import com.texthip.thip.data.model.book.response.BookSearchItem
 import com.texthip.thip.data.model.book.response.PopularBookItem
+import com.texthip.thip.data.model.book.response.RecentSearchItem
 
 data class SearchBookUiState(
     val searchQuery: String = "",
     val liveSearchResults: List<BookSearchItem> = emptyList(), // Live search 결과 (검색어 입력 시)
     val searchResults: List<BookSearchItem> = emptyList(), // 완료된 검색 결과 (검색 버튼 클릭 시)
     val popularBooks: List<PopularBookItem> = emptyList(), // 인기 책 목록
+    val recentSearches: List<RecentSearchItem> = emptyList(), // 최근 검색어 목록
     val isLiveSearching: Boolean = false, // Live search 로딩 상태
     val isSearching: Boolean = false, // 완료된 검색 로딩 상태
     val isLoadingPopularBooks: Boolean = false, // 인기 책 로딩 상태
+    val isLoadingRecentSearches: Boolean = false, // 최근 검색어 로딩 상태
     val isLoadingMore: Boolean = false,
     val isLiveLoadingMore: Boolean = false, // Live search 무한 스크롤 로딩
     val hasMorePages: Boolean = true,

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
@@ -4,15 +4,13 @@ import com.texthip.thip.data.model.book.response.BookSearchItem
 import com.texthip.thip.data.model.book.response.PopularBookItem
 import com.texthip.thip.data.model.book.response.RecentSearchItem
 
-sealed class SearchMode {
-    object Initial : SearchMode()
-    object LiveSearch : SearchMode()
-    object CompleteSearch : SearchMode()
-}
-
 data class SearchBookUiState(
     val searchQuery: String = "",
-    val searchMode: SearchMode = SearchMode.Initial,
+    
+    // 상태 관리 단순화 - boolean 필드 사용
+    val isInitial: Boolean = true,
+    val isLiveSearching: Boolean = false,
+    val isCompleteSearching: Boolean = false,
     
     // 통합된 검색 결과 (Live/Complete 구분 없이)
     val searchResults: List<BookSearchItem> = emptyList(),
@@ -36,5 +34,6 @@ data class SearchBookUiState(
     val hasResults: Boolean get() = searchResults.isNotEmpty()
     val canLoadMore: Boolean get() = hasMorePages && !isSearching && !isLoadingMore
     val showEmptyState: Boolean get() = searchQuery.isNotBlank() && searchResults.isEmpty() && !isSearching
-    val showInitialScreen: Boolean get() = searchMode == SearchMode.Initial && searchQuery.isBlank()
+    val showInitialScreen: Boolean get() = isInitial && searchQuery.isBlank()
+    val isAnySearching: Boolean get() = isLiveSearching || isCompleteSearching
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
@@ -1,13 +1,16 @@
 package com.texthip.thip.ui.search.viewmodel
 
 import com.texthip.thip.data.model.book.response.BookSearchItem
+import com.texthip.thip.data.model.book.response.PopularBookItem
 
 data class SearchBookUiState(
     val searchQuery: String = "",
     val liveSearchResults: List<BookSearchItem> = emptyList(), // Live search 결과 (검색어 입력 시)
     val searchResults: List<BookSearchItem> = emptyList(), // 완료된 검색 결과 (검색 버튼 클릭 시)
+    val popularBooks: List<PopularBookItem> = emptyList(), // 인기 책 목록
     val isLiveSearching: Boolean = false, // Live search 로딩 상태
     val isSearching: Boolean = false, // 완료된 검색 로딩 상태
+    val isLoadingPopularBooks: Boolean = false, // 인기 책 로딩 상태
     val isLoadingMore: Boolean = false,
     val isLiveLoadingMore: Boolean = false, // Live search 무한 스크롤 로딩
     val hasMorePages: Boolean = true,

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
@@ -4,35 +4,37 @@ import com.texthip.thip.data.model.book.response.BookSearchItem
 import com.texthip.thip.data.model.book.response.PopularBookItem
 import com.texthip.thip.data.model.book.response.RecentSearchItem
 
+sealed class SearchMode {
+    object Initial : SearchMode()
+    object LiveSearch : SearchMode()
+    object CompleteSearch : SearchMode()
+}
+
 data class SearchBookUiState(
     val searchQuery: String = "",
-    val liveSearchResults: List<BookSearchItem> = emptyList(), // Live search 결과 (검색어 입력 시)
-    val searchResults: List<BookSearchItem> = emptyList(), // 완료된 검색 결과 (검색 버튼 클릭 시)
-    val popularBooks: List<PopularBookItem> = emptyList(), // 인기 책 목록
-    val recentSearches: List<RecentSearchItem> = emptyList(), // 최근 검색어 목록
-    val isLiveSearching: Boolean = false, // Live search 로딩 상태
-    val isSearching: Boolean = false, // 완료된 검색 로딩 상태
-    val isLoadingPopularBooks: Boolean = false, // 인기 책 로딩 상태
-    val isLoadingRecentSearches: Boolean = false, // 최근 검색어 로딩 상태
+    val searchMode: SearchMode = SearchMode.Initial,
+    
+    // 통합된 검색 결과 (Live/Complete 구분 없이)
+    val searchResults: List<BookSearchItem> = emptyList(),
+    val popularBooks: List<PopularBookItem> = emptyList(),
+    val recentSearches: List<RecentSearchItem> = emptyList(),
+    
+    // 로딩 상태
+    val isSearching: Boolean = false,
     val isLoadingMore: Boolean = false,
-    val isLiveLoadingMore: Boolean = false, // Live search 무한 스크롤 로딩
-    val hasMorePages: Boolean = true,
-    val liveHasMorePages: Boolean = true, // Live search 페이징 정보
-    val isFirstPage: Boolean = true,
+    
+    // 페이징 정보
     val currentPage: Int = 1,
-    val liveCurrentPage: Int = 1, // Live search 현재 페이지
-    val totalPages: Int = 0,
-    val liveTotalPages: Int = 0, // Live search 총 페이지
     val totalElements: Int = 0,
-    val liveTotalElements: Int = 0, // Live search 총 요소
-    val isSearchCompleted: Boolean = false, // 검색 버튼을 눌러서 완료된 검색인지
+    val hasMorePages: Boolean = true,
+    
+    // 에러/토스트
     val error: String? = null,
     val showToast: Boolean = false,
     val toastMessage: String = ""
 ) {
-    val hasLiveResults: Boolean get() = liveSearchResults.isNotEmpty()
-    val hasSearchResults: Boolean get() = searchResults.isNotEmpty() && isSearchCompleted
-    val canLoadMore: Boolean get() = hasMorePages && !isSearching && !isLoadingMore && isSearchCompleted
-    val canLiveLoadMore: Boolean get() = liveHasMorePages && !isLiveSearching && !isLiveLoadingMore && !isSearchCompleted
-    val showEmptyState: Boolean get() = searchQuery.isNotBlank() && liveSearchResults.isEmpty() && !isLiveSearching && !isSearchCompleted
+    val hasResults: Boolean get() = searchResults.isNotEmpty()
+    val canLoadMore: Boolean get() = hasMorePages && !isSearching && !isLoadingMore
+    val showEmptyState: Boolean get() = searchQuery.isNotBlank() && searchResults.isEmpty() && !isSearching
+    val showInitialScreen: Boolean get() = searchMode == SearchMode.Initial && searchQuery.isBlank()
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookUiState.kt
@@ -34,6 +34,4 @@ data class SearchBookUiState(
     val hasResults: Boolean get() = searchResults.isNotEmpty()
     val canLoadMore: Boolean get() = hasMorePages && !isSearching && !isLoadingMore
     val showEmptyState: Boolean get() = searchQuery.isNotBlank() && searchResults.isEmpty() && !isSearching
-    val showInitialScreen: Boolean get() = isInitial && searchQuery.isBlank()
-    val isAnySearching: Boolean get() = isLiveSearching || isCompleteSearching
 }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -32,13 +33,14 @@ class SearchBookViewModel @Inject constructor(
     }
     
     private fun updateState(update: (SearchBookUiState) -> SearchBookUiState) {
-        _uiState.value = update(_uiState.value)
+        _uiState.update(update)
     }
 
     fun updateSearchQuery(query: String) {
         updateState { it.copy(searchQuery = query) }
-
         searchJob?.cancel()
+        loadMoreJob?.cancel()
+
         if (query.isNotBlank()) {
             updateState { 
                 it.copy(
@@ -60,6 +62,8 @@ class SearchBookViewModel @Inject constructor(
         val query = uiState.value.searchQuery.trim()
         if (query.isNotBlank()) {
             searchJob?.cancel()
+            loadMoreJob?.cancel()
+
             updateState { 
                 it.copy(
                     isInitial = false,
@@ -114,6 +118,7 @@ class SearchBookViewModel @Inject constructor(
                             isSearching = false,
                             isLiveSearching = false,
                             isCompleteSearching = false,
+                            hasMorePages = false,
                             error = if (isLiveSearch) null else "검색 결과를 불러올 수 없습니다."
                         )
                     }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
@@ -78,7 +78,7 @@ class SearchBookViewModel @Inject constructor(
             ) 
         }
 
-        bookRepository.searchBooks(query, 1)
+        bookRepository.searchBooks(query, 1, isFinalized = !isLiveSearch)
             .onSuccess { response ->
                 response?.let { searchResponse ->
                     updateState {
@@ -118,7 +118,7 @@ class SearchBookViewModel @Inject constructor(
         
         updateState { it.copy(isLoadingMore = true) }
 
-        bookRepository.searchBooks(currentState.searchQuery, nextPage)
+        bookRepository.searchBooks(currentState.searchQuery, nextPage, isFinalized = true)
             .onSuccess { response ->
                 response?.let { searchResponse ->
                     updateState {

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
@@ -112,6 +112,8 @@ class SearchBookViewModel @Inject constructor(
                         it.copy(
                             searchResults = emptyList(),
                             isSearching = false,
+                            isLiveSearching = false,
+                            isCompleteSearching = false,
                             error = if (isLiveSearch) null else "검색 결과를 불러올 수 없습니다."
                         )
                     }
@@ -122,6 +124,8 @@ class SearchBookViewModel @Inject constructor(
                     it.copy(
                         searchResults = emptyList(),
                         isSearching = false,
+                        isLiveSearching = false,
+                        isCompleteSearching = false,
                         error = if (isLiveSearch) null else (throwable.message ?: "검색 중 오류가 발생했습니다.")
                     )
                 }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
@@ -38,7 +38,7 @@ class SearchBookViewModel @Inject constructor(
         if (query.isNotBlank()) {
             updateState { it.copy(searchMode = SearchMode.LiveSearch) }
             searchJob = viewModelScope.launch {
-                delay(1000) // 디바운싱
+                delay(1000) // Live search에 딜레이 추가
                 performSearch(query, isLiveSearch = true)
             }
         } else {
@@ -78,8 +78,6 @@ class SearchBookViewModel @Inject constructor(
                     currentPage = 1
                 ) 
             }
-
-            delay(if (isLiveSearch) 0 else 1000) // Complete search에만 딜레이
 
             bookRepository.searchBooks(query, 1)
                 .onSuccess { response ->
@@ -130,7 +128,6 @@ class SearchBookViewModel @Inject constructor(
             val nextPage = currentState.currentPage + 1
             
             updateState { it.copy(isLoadingMore = true) }
-            delay(1000) // 로딩 표시를 위한 딜레이
 
             bookRepository.searchBooks(currentState.searchQuery, nextPage)
                 .onSuccess { response ->

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
@@ -135,6 +135,7 @@ class SearchBookViewModel @Inject constructor(
                     updateState {
                         it.copy(
                             isLoadingMore = false,
+                            hasMorePages = false, // null 응답 시 더 이상 페이지가 없음을 명시
                             error = "추가 결과를 불러올 수 없습니다."
                         )
                     }

--- a/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/search/viewmodel/SearchBookViewModel.kt
@@ -1,0 +1,319 @@
+package com.texthip.thip.ui.search.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.texthip.thip.data.repository.BookRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchBookViewModel @Inject constructor(
+    private val bookRepository: BookRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SearchBookUiState())
+    val uiState: StateFlow<SearchBookUiState> = _uiState.asStateFlow()
+    
+    private var searchJob: Job? = null
+    private var loadMoreJob: Job? = null
+    
+    private fun updateState(update: (SearchBookUiState) -> SearchBookUiState) {
+        _uiState.value = update(_uiState.value)
+    }
+
+    fun updateSearchQuery(query: String) {
+        updateState { it.copy(searchQuery = query, isSearchCompleted = false) }
+        
+        // Live search with debounce
+        searchJob?.cancel()
+        if (query.isNotBlank()) {
+            searchJob = viewModelScope.launch {
+                delay(300) // debounce
+                performLiveSearch(query)
+            }
+        } else {
+            clearSearchResults()
+        }
+    }
+
+    fun onSearchButtonClick() {
+        val query = uiState.value.searchQuery.trim()
+        if (query.isNotBlank()) {
+            performCompleteSearch(query)
+        }
+    }
+
+    fun loadMoreBooks() {
+        val currentState = uiState.value
+        if (currentState.canLoadMore && currentState.searchQuery.isNotBlank()) {
+            loadMoreJob?.cancel()
+            loadMoreJob = viewModelScope.launch {
+                performLoadMore(currentState.searchQuery)
+            }
+        }
+    }
+
+    fun loadMoreLiveSearchResults() {
+        val currentState = uiState.value
+        if (currentState.canLiveLoadMore && currentState.searchQuery.isNotBlank()) {
+            loadMoreJob?.cancel()
+            loadMoreJob = viewModelScope.launch {
+                performLiveSearchLoadMore(currentState.searchQuery)
+            }
+        }
+    }
+
+    private fun performLiveSearch(query: String) {
+        viewModelScope.launch {
+            try {
+                updateState { 
+                    it.copy(
+                        isLiveSearching = true, 
+                        error = null,
+                        liveSearchResults = emptyList(), // 기존 Live search 결과 클리어
+                        liveCurrentPage = 1
+                    ) 
+                }
+
+                bookRepository.searchBooks(query, 1)
+                    .onSuccess { searchResponse ->
+                        searchResponse?.let { response ->
+                            updateState {
+                                it.copy(
+                                    liveSearchResults = response.searchResult, // Live search는 전체 결과 표시 (무한스크롤 포함)
+                                    liveCurrentPage = response.page,
+                                    liveTotalPages = response.totalPages,
+                                    liveTotalElements = response.totalElements,
+                                    liveHasMorePages = !response.last,
+                                    isLiveSearching = false,
+                                    error = null
+                                )
+                            }
+                        } ?: run {
+                            updateState {
+                                it.copy(
+                                    liveSearchResults = emptyList(),
+                                    isLiveSearching = false,
+                                    error = null
+                                )
+                            }
+                        }
+                    }
+                    .onFailure {
+                        updateState {
+                            it.copy(
+                                liveSearchResults = emptyList(),
+                                isLiveSearching = false,
+                                error = null // Live search 에러는 조용히 처리
+                            )
+                        }
+                    }
+            } catch (e: Exception) {
+                updateState {
+                    it.copy(
+                        liveSearchResults = emptyList(),
+                        isLiveSearching = false,
+                        error = null
+                    )
+                }
+            }
+        }
+    }
+
+    private fun performLiveSearchLoadMore(query: String) {
+        viewModelScope.launch {
+            try {
+                val currentState = uiState.value
+                val nextPage = currentState.liveCurrentPage + 1
+                
+                updateState { it.copy(isLiveLoadingMore = true) }
+
+                bookRepository.searchBooks(query, nextPage)
+                    .onSuccess { searchResponse ->
+                        searchResponse?.let { response ->
+                            updateState {
+                                it.copy(
+                                    liveSearchResults = it.liveSearchResults + response.searchResult,
+                                    liveCurrentPage = response.page,
+                                    liveTotalPages = response.totalPages,
+                                    liveTotalElements = response.totalElements,
+                                    liveHasMorePages = !response.last,
+                                    isLiveLoadingMore = false,
+                                    error = null
+                                )
+                            }
+                        } ?: run {
+                            updateState {
+                                it.copy(
+                                    isLiveLoadingMore = false,
+                                    error = null
+                                )
+                            }
+                        }
+                    }
+                    .onFailure {
+                        updateState {
+                            it.copy(
+                                isLiveLoadingMore = false,
+                                error = null // Live search 에러는 조용히 처리
+                            )
+                        }
+                    }
+            } catch (e: Exception) {
+                updateState {
+                    it.copy(
+                        isLiveLoadingMore = false,
+                        error = null
+                    )
+                }
+            }
+        }
+    }
+
+    private fun performCompleteSearch(query: String) {
+        viewModelScope.launch {
+            try {
+                updateState { 
+                    it.copy(
+                        isSearching = true, 
+                        isSearchCompleted = true,
+                        error = null,
+                        searchResults = emptyList(), // 기존 검색 결과 클리어
+                        currentPage = 1
+                    ) 
+                }
+
+                bookRepository.searchBooks(query, 1)
+                    .onSuccess { searchResponse ->
+                        searchResponse?.let { response ->
+                            updateState {
+                                it.copy(
+                                    searchResults = response.searchResult,
+                                    currentPage = response.page,
+                                    totalPages = response.totalPages,
+                                    totalElements = response.totalElements,
+                                    hasMorePages = !response.last,
+                                    isFirstPage = response.first,
+                                    isSearching = false,
+                                    error = null
+                                )
+                            }
+                        } ?: run {
+                            updateState {
+                                it.copy(
+                                    searchResults = emptyList(),
+                                    isSearching = false,
+                                    error = "검색 결과를 불러올 수 없습니다."
+                                )
+                            }
+                        }
+                    }
+                    .onFailure { throwable ->
+                        updateState {
+                            it.copy(
+                                searchResults = emptyList(),
+                                isSearching = false,
+                                error = throwable.message ?: "검색 중 오류가 발생했습니다."
+                            )
+                        }
+                    }
+            } catch (e: Exception) {
+                updateState {
+                    it.copy(
+                        searchResults = emptyList(),
+                        isSearching = false,
+                        error = e.message ?: "검색 중 오류가 발생했습니다."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun performLoadMore(query: String) {
+        viewModelScope.launch {
+            try {
+                val currentState = uiState.value
+                val nextPage = currentState.currentPage + 1
+                
+                updateState { it.copy(isLoadingMore = true) }
+
+                bookRepository.searchBooks(query, nextPage)
+                    .onSuccess { searchResponse ->
+                        searchResponse?.let { response ->
+                            updateState {
+                                it.copy(
+                                    searchResults = it.searchResults + response.searchResult,
+                                    currentPage = response.page,
+                                    totalPages = response.totalPages,
+                                    totalElements = response.totalElements,
+                                    hasMorePages = !response.last,
+                                    isLoadingMore = false,
+                                    error = null
+                                )
+                            }
+                        } ?: run {
+                            updateState {
+                                it.copy(
+                                    isLoadingMore = false,
+                                    error = "추가 결과를 불러올 수 없습니다."
+                                )
+                            }
+                        }
+                    }
+                    .onFailure { throwable ->
+                        updateState {
+                            it.copy(
+                                isLoadingMore = false,
+                                error = throwable.message ?: "추가 결과를 불러오는 중 오류가 발생했습니다."
+                            )
+                        }
+                    }
+            } catch (e: Exception) {
+                updateState {
+                    it.copy(
+                        isLoadingMore = false,
+                        error = e.message ?: "추가 결과를 불러오는 중 오류가 발생했습니다."
+                    )
+                }
+            }
+        }
+    }
+
+
+    private fun clearSearchResults() {
+        searchJob?.cancel()
+        loadMoreJob?.cancel()
+        updateState {
+            SearchBookUiState(searchQuery = it.searchQuery)
+        }
+    }
+
+    fun showToastMessage(message: String) {
+        updateState {
+            it.copy(
+                toastMessage = message,
+                showToast = true
+            )
+        }
+    }
+
+    fun hideToast() {
+        updateState { it.copy(showToast = false) }
+    }
+
+    fun clearError() {
+        updateState { it.copy(error = null) }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        searchJob?.cancel()
+        loadMoreJob?.cancel()
+    }
+}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">3.37.87.117</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #67 

<br/>

## 🔎 작업 내용

- [x] 책 저장 상태변경
- [x] 책으로 모집중인 모임방 조회
- [x] 책 상세 조회
- [x] 책 검색 결과
- [x] 가장 많이 검색된 책 조회
- [x] 최근 검색어 조회
- [x] 최근 검색어 삭제

 <br/>

## 📸 스크린샷  

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 😢 해결하지 못한 과제

- [ ] 책 검색 로직이 수~목 중에 수정된다고 합니다
- [ ] 해당 책으로 모집중인 모임방 화면에서 모임방 생성 화면으로 연결하는 로직은 구현 중에 있습니다.

  <br/>

## 📢 리뷰어들에게
- 참고해야 할 사항들을 적어주세요

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 도서 검색(실시간/전체)·상세조회·저장·최근·인기 검색, 모집방 조회 및 관련 뷰모델·페이징·상태관리 추가
  - 도서 기반 그룹 만들기(사전입력) 및 도서 등록 요청 흐름 추가

- **내비게이션**
  - 검색→도서상세/도서모임, 공통→도서등록, 그룹→사전입력 방 만들기 등 경로 및 바로가기 확장

- **UI/UX**
  - 리스트 무한스크롤·하단 로딩 인디케이터·항목 클릭 처리·구분선, 장르칩 전체 클릭성 개선, 등록화면 좌측 버튼 콜백 추가

- **기타**
  - 특정 호스트에 대한 cleartext(HTTP) 허용 네트워크 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->