### PR TITLE
REFACTOR] QA 반영 2차

### DIFF
--- a/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedCommentScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedCommentScreen.kt
@@ -308,6 +308,7 @@ fun FeedCommentScreen(
                                 isSaveVisible = true,
                                 isSaved = feedDetail.isSaved,
                                 isPinVisible = false,
+                                isLockIcon = feedDetail.isPublic == false,
                                 onLikeClick = { feedDetailViewModel.changeFeedLike() },
                                 onCommentClick = { /* 스크롤 이동 or 포커스 처리 */ },
                                 onBookmarkClick = { feedDetailViewModel.changeFeedSave() },

--- a/app/src/main/java/com/texthip/thip/ui/feed/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/viewmodel/FeedViewModel.kt
@@ -32,8 +32,8 @@ data class FeedUiState(
     val isLastPageMyFeeds: Boolean = false,
     val error: String? = null
 ) {
-    val canLoadMoreAllFeeds: Boolean get() = !isLoading && !isLoadingMore && !isRefreshing && !isLastPageAllFeeds
-    val canLoadMoreMyFeeds: Boolean get() = !isLoading && !isLoadingMore && !isRefreshing && !isLastPageMyFeeds
+    val canLoadMoreAllFeeds: Boolean get() = !isLoading && !isLoadingMore && !isRefreshing && !isPullToRefreshing && !isLastPageAllFeeds
+    val canLoadMoreMyFeeds: Boolean get() = !isLoading && !isLoadingMore && !isRefreshing && !isPullToRefreshing && !isLastPageMyFeeds
     val currentTabFeeds: List<Any>
         get() = when (selectedTabIndex) {
             0 -> allFeeds

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/component/GroupDatePicker.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/component/GroupDatePicker.kt
@@ -28,11 +28,11 @@ import java.time.LocalDate
 
 @Composable
 fun GroupDatePicker(
+    modifier: Modifier = Modifier,
     selectedDate: LocalDate,
     minDate: LocalDate,
     maxDate: LocalDate,
-    onDateSelected: (LocalDate) -> Unit,
-    modifier: Modifier = Modifier
+    onDateSelected: (LocalDate) -> Unit
 ) {
     // 선택된 날짜에서 년/월/일 추출
     val year = selectedDate.year
@@ -55,7 +55,7 @@ fun GroupDatePicker(
             verticalAlignment = Alignment.CenterVertically
         ) {
             GroupWheelPicker(
-                modifier = Modifier.width(48.dp),
+                modifier = modifier.width(48.dp),
                 items = years,
                 selectedItem = year,
                 onItemSelected = { newYear ->

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/component/GroupRoomDurationPicker.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/component/GroupRoomDurationPicker.kt
@@ -114,7 +114,6 @@ fun GroupRoomDurationPicker(
                     startDate = newDate
                 },
                 modifier = Modifier
-                    .weight(1f)
                     .pointerInput(Unit) {
                         detectTapGestures(
                             onPress = { isPickerTouched = true }
@@ -139,7 +138,6 @@ fun GroupRoomDurationPicker(
                     endDate = newDate
                 },
                 modifier = Modifier
-                    .weight(1f)
                     .pointerInput(Unit) {
                         detectTapGestures(
                             onPress = { isPickerTouched = true }

--- a/app/src/main/java/com/texthip/thip/ui/group/makeroom/screen/GroupMakeRoomScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/makeroom/screen/GroupMakeRoomScreen.kt
@@ -43,6 +43,7 @@ import com.texthip.thip.ui.group.makeroom.viewmodel.GroupMakeRoomViewModel
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
+import com.texthip.thip.utils.rooms.advancedImePadding
 import com.texthip.thip.utils.rooms.toDisplayStrings
 
 
@@ -106,7 +107,7 @@ fun GroupMakeRoomContent(
 ) {
     val scrollState = rememberScrollState()
 
-    Box {
+    Box(modifier = Modifier.advancedImePadding()) {
         Column(
             modifier = modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomRecruitScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomRecruitScreen.kt
@@ -281,7 +281,7 @@ fun GroupRoomRecruitContent(
                         //참여 인원
                         Column(
                             verticalArrangement = Arrangement.Center,
-                            modifier = Modifier.padding(start = 90.dp)
+                            modifier = Modifier.padding(start = 50.dp)
                         ) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomUnlockScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomUnlockScreen.kt
@@ -36,6 +36,7 @@ import com.texthip.thip.ui.group.room.viewmodel.GroupRoomUnlockViewModel
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
+import com.texthip.thip.utils.rooms.advancedImePadding
 import kotlinx.coroutines.delay
 
 @Composable
@@ -96,7 +97,7 @@ fun GroupRoomUnlockScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().advancedImePadding()) {
         Column(
             modifier = Modifier.fillMaxSize()
         ) {

--- a/app/src/main/java/com/texthip/thip/ui/mypage/component/SavedFeedCard.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/component/SavedFeedCard.kt
@@ -79,6 +79,7 @@ fun SavedFeedCard(
 
         Column(
             modifier = Modifier
+                .padding(bottom = 16.dp)
                 .clickable { onContentClick() }, // 전체 영역 클릭 유지
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
@@ -89,8 +90,7 @@ fun SavedFeedCard(
                     style = typography.feedcopy_r400_s14_h20,
                     color = colors.White,
                     maxLines = maxLines,
-                    modifier = Modifier
-                        .fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     onTextLayout = { textLayoutResult ->
                         isTextTruncated = textLayoutResult.hasVisualOverflow
                     }


### PR DESCRIPTION
## ➕ 이슈 링크

<br/>

## 🔎 작업 내용

- [x] 갤러리 이미지 개수제한 구현
- [x] 모집중인 모임방 패딩 수정
- [x] 모임방 생성 비밀번호 입력시 키보드 패딩 추가
- [x] 전체 피드 게시글 글자 패딩 수정
- [x] 자물쇠 아이콘 연결

 <br/>

## 📸 스크린샷  

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 😢 해결하지 못한 과제
- [ ] 비밀글일때 lock 아이콘 구현 (해당 책으로 모집중인 모임방)
- [ ] 피드 게시글에서 자세히보기 화면 보다가 뒤로가기 하면 피드 스크롤 상태 초기화 문제 

  <br/>

## 📢 리뷰어들에게
- 참고해야 할 사항들을 적어주세요

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Android 13+ 사진 선택기 지원(여러 장 선택, 남은 슬롯 제한 적용).
  - 비공개 피드에 잠금 아이콘 표시.

- Bug Fixes
  - 당겨서 새로고침 중 추가 로딩 방지.
  - 키보드 표시 시 화면 가림 현상 완화(입력 영역 패딩 적용).

- Style
  - 그룹 모집/방만들기/잠금 화면 및 저장한 피드 카드의 여백·정렬 조정.
  - 그룹 기간 선택기의 너비 분배 조정으로 가독성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->