### PR TITLE
[FEAT] 저장 조회 화면 api 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ local.properties
 .idea/deploymentTargetSelector.xml
 .idea/misc.xml
 .idea/gradle.xml
+.idea/appInsightsSettings.xml

--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -8,10 +8,10 @@
             <InsightsFilterSettings>
               <option name="connection">
                 <ConnectionSetting>
-                  <option name="appId" value="PLACEHOLDER" />
-                  <option name="mobileSdkAppId" value="" />
-                  <option name="projectId" value="" />
-                  <option name="projectNumber" value="" />
+                  <option name="appId" value="com.texthip.thip" />
+                  <option name="mobileSdkAppId" value="1:353417813537:android:69029c2bc957df7fab4d60" />
+                  <option name="projectId" value="thip-3a698" />
+                  <option name="projectNumber" value="353417813537" />
                 </ConnectionSetting>
               </option>
               <option name="signal" value="SIGNAL_UNSPECIFIED" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CodeInsightWorkspaceSettings">
     <option name="optimizeImportsOnTheFly" value="true" />

--- a/app/src/main/java/com/texthip/thip/data/model/book/response/BookUserSaveResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/book/response/BookUserSaveResponse.kt
@@ -1,0 +1,19 @@
+package com.texthip.thip.data.model.book.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookUserSaveResponse(
+    val bookList: List<BookUserSaveList>
+)
+
+@Serializable
+data class BookUserSaveList(
+    val bookId: Int,
+    val bookTitle: String,
+    val authorName: String,
+    val publisher: String,
+    val bookImageUrl: String? = null,
+    val isbn: String = "",
+    val isSaved: Boolean = true
+)

--- a/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/BookRepository.kt
@@ -6,6 +6,7 @@ import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
 import com.texthip.thip.data.model.book.response.BookSaveResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
+import com.texthip.thip.data.model.book.response.BookUserSaveResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecruitingRoomsResponse
 import com.texthip.thip.data.service.BookService
@@ -25,7 +26,11 @@ class BookRepository @Inject constructor(
     }
 
     /** 책 검색 */
-    suspend fun searchBooks(keyword: String, page: Int = 1, isFinalized: Boolean = false): Result<BookSearchResponse?> = runCatching {
+    suspend fun searchBooks(
+        keyword: String,
+        page: Int = 1,
+        isFinalized: Boolean = false
+    ): Result<BookSearchResponse?> = runCatching {
         bookService.searchBooks(keyword, page, isFinalized)
             .handleBaseResponse()
             .getOrThrow()
@@ -53,8 +58,17 @@ class BookRepository @Inject constructor(
     }
 
     /** 모집중인 방 조회 */
-    suspend fun getRecruitingRooms(isbn: String, cursor: String? = null): Result<RecruitingRoomsResponse?> = runCatching {
+    suspend fun getRecruitingRooms(
+        isbn: String,
+        cursor: String? = null
+    ): Result<RecruitingRoomsResponse?> = runCatching {
         bookService.getRecruitingRooms(isbn, cursor)
+            .handleBaseResponse()
+            .getOrThrow()
+    }
+
+    suspend fun getSavedBooks(): Result<BookUserSaveResponse?> = runCatching {
+        bookService.getSavedBooks()
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/FeedRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/FeedRepository.kt
@@ -293,4 +293,9 @@ class FeedRepository @Inject constructor(
             }
         }
 
+    suspend fun getSavedFeeds(cursor: String? = null): Result<AllFeedResponse?> = runCatching {
+        feedService.getSavedFeeds(cursor)
+            .handleBaseResponse()
+            .getOrThrow()
+    }
 }

--- a/app/src/main/java/com/texthip/thip/data/service/BookService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/BookService.kt
@@ -6,6 +6,7 @@ import com.texthip.thip.data.model.book.response.BookDetailResponse
 import com.texthip.thip.data.model.book.response.BookListResponse
 import com.texthip.thip.data.model.book.response.BookSaveResponse
 import com.texthip.thip.data.model.book.response.BookSearchResponse
+import com.texthip.thip.data.model.book.response.BookUserSaveResponse
 import com.texthip.thip.data.model.book.response.MostSearchedBooksResponse
 import com.texthip.thip.data.model.book.response.RecruitingRoomsResponse
 import retrofit2.http.Body
@@ -53,4 +54,7 @@ interface BookService {
         @Path("isbn") isbn: String,
         @Query("cursor") cursor: String? = null
     ): BaseResponse<RecruitingRoomsResponse>
+
+    @GET("books/saved")
+    suspend fun getSavedBooks(): BaseResponse<BookUserSaveResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/FeedService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/FeedService.kt
@@ -108,4 +108,9 @@ interface FeedService {
         @Path("feedId") feedId: Long,
         @Body request: FeedSaveRequest
     ): BaseResponse<FeedSaveResponse>
+
+    @GET("feeds/saved")
+    suspend fun getSavedFeeds(
+        @Query("cursor") cursor: String? = null
+    ): BaseResponse<AllFeedResponse>
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/cards/CardItemRoomSmall.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/cards/CardItemRoomSmall.kt
@@ -61,7 +61,6 @@ fun CardItemRoomSmall(
         colors = CardDefaults.cardColors(
             containerColor = bgColor
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         shape = RoundedCornerShape(12.dp)
     ) {
         Column(

--- a/app/src/main/java/com/texthip/thip/ui/common/topappbar/DefaultTopAppBar.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/topappbar/DefaultTopAppBar.kt
@@ -1,6 +1,7 @@
 package com.texthip.thip.ui.common.topappbar
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,7 +41,11 @@ fun DefaultTopAppBar(
             tint = Color.Unspecified,
             modifier = Modifier
                 .align(Alignment.CenterStart)
-                .clickable(onClick = onLeftClick)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onLeftClick
+                )
         )
 
         if (isTitleVisible) {
@@ -58,7 +64,11 @@ fun DefaultTopAppBar(
                 tint = Color.Unspecified,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .clickable(onClick = onRightClick)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onRightClick
+                    )
             )
         }
     }

--- a/app/src/main/java/com/texthip/thip/ui/common/topappbar/DefaultTopAppBar.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/topappbar/DefaultTopAppBar.kt
@@ -1,11 +1,11 @@
 package com.texthip.thip.ui.common.topappbar
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -33,16 +33,14 @@ fun DefaultTopAppBar(
             .fillMaxWidth()
             .padding(horizontal = 20.dp, vertical = 16.dp)
     ) {
-        IconButton(
-            onClick = onLeftClick,
-            modifier = Modifier.align(Alignment.CenterStart)
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_arrow_back),
-                contentDescription = "Back Button",
-                tint = Color.Unspecified
-            )
-        }
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_back),
+            contentDescription = "Back Button",
+            tint = Color.Unspecified,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .clickable(onClick = onLeftClick)
+        )
 
         if (isTitleVisible) {
             Text(
@@ -54,16 +52,14 @@ fun DefaultTopAppBar(
         }
 
         if (isRightIconVisible) {
-            IconButton(
-                onClick = onRightClick,
-                modifier = Modifier.align(Alignment.CenterEnd)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_more),
-                    contentDescription = "More Options",
-                    tint = Color.Unspecified
-                )
-            }
+            Icon(
+                painter = painterResource(R.drawable.ic_more),
+                contentDescription = "More Options",
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .clickable(onClick = onRightClick)
+            )
         }
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/topappbar/GradationTopAppBar.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/topappbar/GradationTopAppBar.kt
@@ -3,6 +3,7 @@ package com.texthip.thip.ui.common.topappbar
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -83,7 +84,11 @@ fun GradationTopAppBar(
             tint = Color.Unspecified,
             modifier = Modifier
                 .align(Alignment.CenterStart)
-                .clickable(onClick = onLeftClick)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onLeftClick
+                )
         )
 
         Column {
@@ -96,14 +101,18 @@ fun GradationTopAppBar(
             }
         }
 
-        if(isRightIconVisible) {
+        if (isRightIconVisible) {
             Icon(
                 painter = painterResource(R.drawable.ic_more),
                 contentDescription = "More Options",
                 tint = Color.Unspecified,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .clickable(onClick = onRightClick)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onRightClick
+                    )
             )
         }
     }

--- a/app/src/main/java/com/texthip/thip/ui/common/topappbar/GradationTopAppBar.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/topappbar/GradationTopAppBar.kt
@@ -2,13 +2,13 @@ package com.texthip.thip.ui.common.topappbar
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,6 +35,7 @@ fun GradationTopAppBar(
     autoHideCount: Boolean? = null,
     countDisplayDurationMs: Long = 5000L,
     onLeftClick: () -> Unit,
+    isRightIconVisible: Boolean = false,
     onRightClick: () -> Unit = {},
 ) {
     var isCountVisible by remember { mutableStateOf(isImageVisible) }
@@ -49,9 +50,11 @@ fun GradationTopAppBar(
                     isCountVisible = false
                 }
             }
+
             false -> {
                 isCountVisible = true
             }
+
             null -> {
                 // 기존 동작 유지: isImageVisible 파라미터 사용
                 isCountVisible = isImageVisible
@@ -74,16 +77,14 @@ fun GradationTopAppBar(
             .height(56.dp),
         contentAlignment = Alignment.Center,
     ) {
-        IconButton(
-            onClick = onLeftClick,
-            modifier = Modifier.align(Alignment.CenterStart)
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_arrow_back),
-                contentDescription = "Back Button",
-                tint = Color.Unspecified
-            )
-        }
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_back),
+            contentDescription = "Back Button",
+            tint = Color.Unspecified,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .clickable(onClick = onLeftClick)
+        )
 
         Column {
             AnimatedVisibility(
@@ -95,16 +96,16 @@ fun GradationTopAppBar(
             }
         }
 
-        /*IconButton(
-            onClick = onRightClick,
-            modifier = Modifier.align(Alignment.CenterEnd)
-        ) {
+        if(isRightIconVisible) {
             Icon(
                 painter = painterResource(R.drawable.ic_more),
                 contentDescription = "More Options",
-                tint = Color.Unspecified
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .clickable(onClick = onRightClick)
             )
-        }*/
+        }
     }
 }
 

--- a/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomRecruitScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomRecruitScreen.kt
@@ -201,10 +201,10 @@ fun GroupRoomRecruitContent(
                 Column(
                     Modifier
                         .fillMaxSize()
-                        .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
-                        .verticalScroll(scrollState)
+                        .verticalScroll(scrollState),
                 ) {
                     Row(
+                        modifier = Modifier.padding(horizontal = 20.dp).padding(top = 20.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
@@ -230,7 +230,9 @@ fun GroupRoomRecruitContent(
                     }
 
                     Text(
-                        modifier = Modifier.padding(top = 40.dp),
+                        modifier = Modifier
+                            .padding(horizontal = 20.dp)
+                            .padding(top = 40.dp),
                         text = stringResource(R.string.group_room_desc),
                         style = typography.menu_sb600_s14_h24,
                         color = colors.White,
@@ -241,11 +243,14 @@ fun GroupRoomRecruitContent(
                         style = typography.copy_r400_s12_h20,
                         color = colors.Grey,
                         modifier = Modifier
+                            .padding(horizontal = 20.dp)
                             .padding(top = 5.dp, bottom = 20.dp)
                     )
 
                     Row(
-                        Modifier.fillMaxWidth(),
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         //모집 기간
@@ -327,6 +332,7 @@ fun GroupRoomRecruitContent(
                     Row(
                         Modifier
                             .fillMaxWidth()
+                            .padding(horizontal = 20.dp)
                             .padding(top = 22.dp, bottom = 30.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -373,6 +379,7 @@ fun GroupRoomRecruitContent(
 
                     //읽을 책 정보
                     CardRoomBook(
+                        modifier = Modifier.padding(horizontal = 20.dp),
                         title = detail.bookTitle,
                         author = detail.authorName,
                         publisher = detail.publisher,
@@ -384,7 +391,7 @@ fun GroupRoomRecruitContent(
                     // 추천 모임방이 있을 때만 표시
                     if (detail.recommendRooms.isNotEmpty()) {
                         Text(
-                            modifier = Modifier.padding(top = 40.dp),
+                            modifier = Modifier.padding(top = 40.dp, start = 20.dp),
                             text = stringResource(R.string.group_recommend),
                             style = typography.smalltitle_sb600_s18_h24,
                             color = colors.White
@@ -393,7 +400,7 @@ fun GroupRoomRecruitContent(
                         //추천 모임방
                         LazyRow(
                             modifier = Modifier
-                                .padding(top = 24.dp)
+                                .padding(top = 24.dp, start = 20.dp)
                                 .fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(20.dp)
                         ) {
@@ -409,6 +416,8 @@ fun GroupRoomRecruitContent(
                             }
                         }
                     }
+
+                    Spacer(Modifier.height(70.dp))
                 }
             }
         }

--- a/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomScreen.kt
@@ -201,6 +201,7 @@ fun GroupRoomContent(
 
         GradationTopAppBar(
             onLeftClick = onBackClick,
+            isRightIconVisible = true,
             onRightClick = { isBottomSheetVisible = true },
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupFilteredSearchResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupFilteredSearchResult.kt
@@ -3,6 +3,7 @@ package com.texthip.thip.ui.group.search.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,9 +28,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.R
+import com.texthip.thip.data.model.rooms.response.SearchRoomItem
 import com.texthip.thip.ui.common.buttons.GenreChipRow
 import com.texthip.thip.ui.common.cards.CardItemRoomSmall
-import com.texthip.thip.data.model.rooms.response.SearchRoomItem
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
@@ -48,7 +49,7 @@ fun GroupFilteredSearchResult(
 ) {
     Column {
         GenreChipRow(
-            modifier = Modifier.width(20.dp),
+            modifier = Modifier.width(12.dp),
             genres = genres,
             selectedIndex = selectedGenreIndex,
             onSelect = onGenreSelect
@@ -94,7 +95,7 @@ fun GroupFilteredSearchResult(
                 }
             }
 
-            LazyColumn(state = listState) {
+            LazyColumn(state = listState, contentPadding = PaddingValues(bottom = 20.dp)) {
                 itemsIndexed(roomList) { index, room ->
                     CardItemRoomSmall(
                         title = room.roomName,

--- a/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupLiveSearchResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupLiveSearchResult.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.ui.group.search.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -19,8 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.texthip.thip.ui.common.cards.CardItemRoomSmall
 import com.texthip.thip.data.model.rooms.response.SearchRoomItem
+import com.texthip.thip.ui.common.cards.CardItemRoomSmall
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 
@@ -48,7 +49,7 @@ fun GroupLiveSearchResult(
         }
     }
 
-    LazyColumn(state = listState) {
+    LazyColumn(state = listState, contentPadding = PaddingValues(bottom = 20.dp)) {
         itemsIndexed(roomList) { index, room ->
             CardItemRoomSmall(
                 title = room.roomName,

--- a/app/src/main/java/com/texthip/thip/ui/mypage/component/BookContent.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/component/BookContent.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.ui.mypage.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -26,16 +27,15 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 fun BookContent(
     bookList: List<BookItem>, viewModel: SavedBookViewModel
 ) {
-    //val books by viewModel.bookList.collectAsState()
-
     if (bookList.isEmpty()) {
         EmptyBookContent()
     } else {
-        LazyColumn (
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 20.dp),
-        ){
+            contentPadding = PaddingValues(bottom = 20.dp)
+        ) {
             itemsIndexed(bookList, key = { _, book -> book.id }) { index, book ->
                 if (index == 0) {
                     Spacer(Modifier.height(32.dp))
@@ -44,11 +44,11 @@ fun BookContent(
                 CardBookList(
                     title = book.title,
                     author = book.author,
-                    imageUrl = null,
+                    imageUrl = book.imageUrl,
                     publisher = book.publisher,
                     showBookmark = true,
                     isBookmarked = book.isSaved,
-                    onBookmarkClick = { viewModel.toggleBookmark(book.id) }
+                    onBookmarkClick = { viewModel.toggleBookmark(book.isbn) }
                 )
 
                 if (index != bookList.lastIndex) {

--- a/app/src/main/java/com/texthip/thip/ui/mypage/component/FeedContent.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/component/FeedContent.kt
@@ -2,6 +2,7 @@ package com.texthip.thip.ui.mypage.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -31,7 +32,8 @@ fun FeedContent(
     } else {
         LazyColumn (
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 20.dp)
         ){
             itemsIndexed(feedList, key = { _,feed -> feed.id }) { index,feed ->
                 if (index == 0) {

--- a/app/src/main/java/com/texthip/thip/ui/mypage/component/SavedFeedCard.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/component/SavedFeedCard.kt
@@ -108,7 +108,7 @@ fun SavedFeedCard(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 16.dp),
+                        .padding(top = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     feedItem.imageUrls.take(3).forEach { imageUrl ->
@@ -126,6 +126,7 @@ fun SavedFeedCard(
         }
 
         ActionBarButton(
+            modifier = Modifier.padding(top = 16.dp),
             isLiked = feedItem.isLiked,
             likeCount = feedItem.likeCount,
             commentCount = feedItem.commentCount,

--- a/app/src/main/java/com/texthip/thip/ui/mypage/mock/BookItem.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/mock/BookItem.kt
@@ -6,5 +6,6 @@ data class BookItem(
     val author: String,
     val publisher: String,
     val imageUrl: String? = null,
+    val isbn: String = "",
     val isSaved: Boolean
 )

--- a/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageSaveScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageSaveScreen.kt
@@ -42,7 +42,7 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 import com.texthip.thip.ui.theme.White
 
 @Composable
-fun SavedScreen(
+fun MypageSaveScreen(
     onNavigateBack: () -> Unit,
     feedViewModel: SavedFeedViewModel = hiltViewModel(),
     bookViewModel: SavedBookViewModel = hiltViewModel()
@@ -132,7 +132,7 @@ fun SavedScreen(
 @Preview
 @Composable
 private fun SavedScreenPrev() {
-    SavedScreen(
+    MypageSaveScreen(
         onNavigateBack = {},
     )
 }
@@ -142,7 +142,7 @@ private fun SavedScreenPrev() {
 @Composable
 private fun SavedScreenWithoutFeedPrev() {
     ThipTheme {
-        SavedScreen(
+        MypageSaveScreen(
             onNavigateBack = {},
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageSaveScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageSaveScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,14 +29,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.texthip.thip.R
 import com.texthip.thip.ui.common.topappbar.DefaultTopAppBar
 import com.texthip.thip.ui.mypage.component.BookContent
-import com.texthip.thip.ui.mypage.component.EmptyBookContent
 import com.texthip.thip.ui.mypage.component.FeedContent
-import com.texthip.thip.ui.mypage.viewmodel.EmptySavedBookViewModel
-import com.texthip.thip.ui.mypage.viewmodel.EmptySavedFeedViewModel
 import com.texthip.thip.ui.mypage.viewmodel.SavedBookViewModel
 import com.texthip.thip.ui.mypage.viewmodel.SavedFeedViewModel
 import com.texthip.thip.ui.theme.ThipTheme
@@ -46,14 +44,20 @@ import com.texthip.thip.ui.theme.White
 @Composable
 fun SavedScreen(
     onNavigateBack: () -> Unit,
-    feedViewModel: SavedFeedViewModel = viewModel(),
-    bookViewModel: SavedBookViewModel = viewModel()
-
+    feedViewModel: SavedFeedViewModel = hiltViewModel(),
+    bookViewModel: SavedBookViewModel = hiltViewModel()
 ) {
     val tabs = listOf(stringResource(R.string.feed), stringResource(R.string.book))
     var selectedTabIndex by rememberSaveable { mutableStateOf(0) }
     val feedList by feedViewModel.feeds.collectAsState()
     val bookList by bookViewModel.books.collectAsState()
+
+    LaunchedEffect(selectedTabIndex) {
+        when (selectedTabIndex) {
+            0 -> feedViewModel.loadSavedFeeds()
+            1 -> bookViewModel.loadSavedBooks()
+        }
+    }
 
     Column(
         Modifier
@@ -68,9 +72,11 @@ fun SavedScreen(
             modifier = Modifier
                 .fillMaxSize()
         ) {
-            Box(modifier = Modifier
-                .width(160.dp)
-                .padding(start = 20.dp)) {
+            Box(
+                modifier = Modifier
+                    .width(160.dp)
+                    .padding(start = 20.dp)
+            ) {
                 TabRow(
                     selectedTabIndex = selectedTabIndex,
                     containerColor = Color.Transparent,
@@ -109,7 +115,9 @@ fun SavedScreen(
                     }
                 }
             }
-            Box(modifier = Modifier .weight(1f) .fillMaxWidth()) {
+            Box(modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()) {
                 when (selectedTabIndex) {
                     0 -> FeedContent(feedList = feedList, viewModel = feedViewModel)
                     1 -> BookContent(bookList = bookList, viewModel = bookViewModel)
@@ -126,8 +134,6 @@ fun SavedScreen(
 private fun SavedScreenPrev() {
     SavedScreen(
         onNavigateBack = {},
-        feedViewModel = SavedFeedViewModel(),
-        bookViewModel = SavedBookViewModel()
     )
 }
 
@@ -138,8 +144,6 @@ private fun SavedScreenWithoutFeedPrev() {
     ThipTheme {
         SavedScreen(
             onNavigateBack = {},
-            feedViewModel = EmptySavedFeedViewModel(),
-            bookViewModel = EmptySavedBookViewModel()
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/mypage/viewmodel/SavedFeedViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/viewmodel/SavedFeedViewModel.kt
@@ -1,112 +1,100 @@
 package com.texthip.thip.ui.mypage.viewmodel
 
 import androidx.lifecycle.ViewModel
-import com.texthip.thip.R
+import androidx.lifecycle.viewModelScope
+import com.texthip.thip.data.model.feed.response.AllFeedItem
+import com.texthip.thip.data.repository.FeedRepository
 import com.texthip.thip.ui.mypage.mock.FeedItem
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-open class SavedFeedViewModel: ViewModel() {
-    private val _feeds = MutableStateFlow(
-        listOf(
-            FeedItem(
-                id = 1L,
-                userProfileImage = "https://example.com/profile.jpg",
-                userName = "user",
-                userRole = "학생",
-                bookTitle = "라랄ㄹ라라",
-                authName = "야야야",
-                timeAgo = "15시간 전",
-                content = "진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공",
-                likeCount = 25,
-                commentCount = 4,
-                isLiked = false,
-                isSaved = true
-            ),
-            FeedItem(
-                id = 2L,
-                userProfileImage = "https://example.com/profile.jpg",
-                userName = "user",
-                userRole = "학생",
-                bookTitle = "라랄ㄹ라라",
-                authName = "야야야",
-                timeAgo = "15시간 전",
-                content = "너무 재밌네요..",
-                likeCount = 25,
-                commentCount = 4,
-                isLiked = false,
-                isSaved = true,
-                imageUrls = emptyList()
-            ),
-            FeedItem(
-                id = 3L,
-                userProfileImage = "https://example.com/profile.jpg",
-                userName = "user",
-                userRole = "학생",
-                bookTitle = "라랄ㄹ라라",
-                authName = "야야야",
-                timeAgo = "15시간 전",
-                content = "너무 재밌네요..",
-                likeCount = 25,
-                commentCount = 4,
-                isLiked = false,
-                isSaved = true,
-                imageUrls = listOf("https://example.com/image.jpg")
-            ),
-            FeedItem(
-                id = 4L,
-                userProfileImage = "https://example.com/profile.jpg",
-                userName = "user",
-                userRole = "학생",
-                bookTitle = "책이름책이름",
-                authName = "저자이름저자이름",
-                timeAgo = "15시간 전",
-                content = "진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공",
-                likeCount = 25,
-                commentCount = 4,
-                isLiked = false,
-                isSaved = true,
-                imageUrls = listOf("https://example.com/image.jpg")
-            ),
-            FeedItem(
-                id = 5L,
-                userProfileImage = "https://example.com/profile.jpg",
-                userName = "user",
-                userRole = "학생",
-                bookTitle = "책이름책이름",
-                authName = "저자이름저자이름",
-                timeAgo = "15시간 전",
-                content = "진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공진짜최공진짜최공진차최공",
-                likeCount = 25,
-                commentCount = 4,
-                isLiked = true,
-                isSaved = true
-            ),
+@HiltViewModel
+class SavedFeedViewModel @Inject constructor(
+    private val feedRepository: FeedRepository
+) : ViewModel() {
 
+    private val _feeds = MutableStateFlow<List<FeedItem>>(emptyList())
+    val feeds = _feeds.asStateFlow()
 
-        )
-    )
-
-
-    open val feeds: StateFlow<List<FeedItem>> = _feeds
-
-    fun toggleBookmark(id: Long) {
-        _feeds.value = _feeds.value.map {
-            if (it.id == id) it.copy(isSaved = !it.isSaved) else it
+    init {
+        viewModelScope.launch {
+            feedRepository.feedStateUpdateResult.collect { update ->
+                _feeds.value = _feeds.value.map { feedItem ->
+                    if (feedItem.id == update.feedId) {
+                        feedItem.copy(
+                            isLiked = update.isLiked,
+                            likeCount = update.likeCount,
+                            isSaved = update.isSaved
+                        )
+                    } else {
+                        feedItem
+                    }
+                }
+            }
         }
     }
 
-    fun toggleLike(id: Long) {
-        _feeds.value = _feeds.value.map {
-            if (it.id == id) it.copy(isLiked = !it.isLiked) else it
+    fun loadSavedFeeds() {
+        viewModelScope.launch {
+            feedRepository.getSavedFeeds()
+                .onSuccess { response ->
+                    _feeds.value = response?.feedList?.map { it.toFeedItem() } ?: emptyList()
+                }
+                .onFailure {
+                    it.printStackTrace()
+                }
+        }
+    }
+
+    fun toggleLike(feedId: Long) {
+        viewModelScope.launch {
+            val feed = _feeds.value.find { it.id == feedId } ?: return@launch
+            feedRepository.changeFeedLike(
+                feedId = feed.id,
+                newLikeStatus = !feed.isLiked,
+                currentLikeCount = feed.likeCount,
+                currentIsSaved = feed.isSaved
+            )
+        }
+    }
+
+    fun toggleBookmark(feedId: Long) {
+        viewModelScope.launch {
+            val feed = _feeds.value.find { it.id == feedId } ?: return@launch
+            feedRepository.changeFeedSave(
+                feedId = feed.id,
+                newSaveStatus = !feed.isSaved,
+                currentIsLiked = feed.isLiked,
+                currentLikeCount = feed.likeCount
+            ).onSuccess {
+                it?.isSaved?.let { it1 ->
+                    if (!it1) {
+                        _feeds.value = _feeds.value.filter { feedItem -> feedItem.id != feedId }
+                    }
+                }
+            }
         }
     }
 }
 
-class EmptySavedFeedViewModel : SavedFeedViewModel() {
-
-    private val _feeds = MutableStateFlow<List<FeedItem>>(emptyList())
-
-    override val feeds: StateFlow<List<FeedItem>> = _feeds
-
+private fun AllFeedItem.toFeedItem(): FeedItem {
+    return FeedItem(
+        id = this.feedId.toLong(),
+        userProfileImage = this.creatorProfileImageUrl,
+        userName = this.creatorNickname,
+        userRole = this.aliasName,
+        bookTitle = this.bookTitle,
+        authName = this.bookAuthor,
+        timeAgo = this.postDate,
+        content = this.contentBody,
+        likeCount = this.likeCount,
+        commentCount = this.commentCount,
+        isLiked = this.isLiked,
+        isSaved = this.isSaved,
+        isLocked = false,
+        imageUrls = this.contentUrls
+    )
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/MyPageNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/MyPageNavigation.kt
@@ -1,6 +1,5 @@
 package com.texthip.thip.ui.navigator.navigations
 
-import androidx.compose.material3.Text
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -8,8 +7,8 @@ import com.texthip.thip.ui.mypage.screen.DeleteAccountScreen
 import com.texthip.thip.ui.mypage.screen.EditProfileScreen
 import com.texthip.thip.ui.mypage.screen.MyPageScreen
 import com.texthip.thip.ui.mypage.screen.MypageCustomerServiceScreen
+import com.texthip.thip.ui.mypage.screen.MypageSaveScreen
 import com.texthip.thip.ui.mypage.screen.NotificationScreen
-import com.texthip.thip.ui.mypage.screen.SavedScreen
 import com.texthip.thip.ui.navigator.extensions.navigateToCustomerService
 import com.texthip.thip.ui.navigator.extensions.navigateToEditProfile
 import com.texthip.thip.ui.navigator.extensions.navigateToLeaveThipScreen
@@ -41,7 +40,7 @@ fun NavGraphBuilder.myPageNavigation(
         )
     }
     composable<MyPageRoutes.Save> {
-        SavedScreen(
+        MypageSaveScreen(
             onNavigateBack = { navController.popBackStack() }
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/signin/screen/LoginScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/screen/LoginScreen.kt
@@ -5,7 +5,6 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -129,8 +128,8 @@ fun LoginContent(
             .padding(horizontal = 20.dp)
             .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
     ) {
+        Spacer(modifier = Modifier.height(300.dp))
         Icon(
             painter = painterResource(R.drawable.ic_logo),
             contentDescription = null,


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #113 

<br/>

## 🔎 작업 내용

- 저장 조회 화면 api 연결했습니다
- 그 외 자잘한 QA 사항들 수정했습니다

 <br/>

## 📸 스크린샷  

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 😢 해결하지 못한 과제
- [] TASK

  <br/>

## 📢 리뷰어들에게
- 참고해야 할 사항들을 적어주세요

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 마이페이지 저장 탭이 서버 기반으로 저장된 피드·도서를 불러오고 갱신합니다.
  - 피드 좋아요/저장 토글 시 목록 상태가 즉시 반영됩니다.
  - 그룹룸 화면 상단바 오른쪽 아이콘이 표시되어 추가 동작을 제공합니다.

- UI
  - 그룹룸 모집/추천 섹션 및 검색 결과 리스트에 하단/수평 패딩을 추가해 가독성을 개선했습니다.
  - 작은 룸 카드의 그림자(입체감)를 기본값으로 조정했습니다.
  - 상단바 아이콘의 클릭 반응을 간결화했습니다(리플 제거).
  - 로그인 화면 레이아웃을 하향 배치해 시각적 균형을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->