### PR TITLE
[Fix] 운영서버에서 회원가입  로직 오류 수정

### DIFF
--- a/app/src/main/java/com/texthip/thip/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/UserRepository.kt
@@ -63,46 +63,11 @@ class UserRepository @Inject constructor(
             .getOrThrow()
     }
 
-    /*suspend fun checkNickname(nickname: String): Result<NicknameResponse?> = runCatching {
-        val tempToken = tokenManager.getTempToken()
-
-        Log.d("SignupDebug", "가져온 임시 토큰: $tempToken")
-
-        if (tempToken.isNullOrBlank()) {
-            return Result.failure(Exception("임시 토큰이 없습니다. 로그인을 다시 시도해주세요."))
-        }
-        userService.checkNickname("Bearer $tempToken",NicknameRequest(nickname))
-            .handleBaseResponse()
-            .getOrThrow()
-    }*/
-    /*suspend fun checkNickname(nickname: String): Result<NicknameResponse?> = runCatching {
-        val tempToken = tokenManager.getTempToken() // <-- runCatching 안으로 이동
-
-        if (tempToken.isNullOrBlank()) {
-            throw Exception("임시 토큰이 없습니다. 로그인을 다시 시도해주세요.")
-        }
-
-        userService.checkNickname("Bearer $tempToken", NicknameRequest(nickname))
-            .handleBaseResponse()
-            .getOrThrow()
-    }*/
     suspend fun checkNickname(nickname: String): Result<NicknameResponse?> = runCatching {
         userService.checkNickname(NicknameRequest(nickname))
             .handleBaseResponse()
             .getOrThrow()
     }
-    /*suspend fun getAliasChoices(): Result<AliasChoiceResponse?> = runCatching {
-        val tempToken = tokenManager.getTempToken()
-
-        Log.d("SignupDebug", "가져온 임시 토큰: $tempToken")
-
-        if (tempToken.isNullOrBlank()) {
-            return Result.failure(Exception("임시 토큰이 없습니다. 로그인을 다시 시도해주세요."))
-        }
-        userService.getAliasChoices("Bearer $tempToken")
-            .handleBaseResponse()
-            .getOrThrow()
-    }*/
     suspend fun getAliasChoices(): Result<AliasChoiceResponse?> = runCatching {
         userService.getAliasChoices()
             .handleBaseResponse()

--- a/app/src/main/java/com/texthip/thip/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/UserRepository.kt
@@ -63,12 +63,46 @@ class UserRepository @Inject constructor(
             .getOrThrow()
     }
 
+    /*suspend fun checkNickname(nickname: String): Result<NicknameResponse?> = runCatching {
+        val tempToken = tokenManager.getTempToken()
+
+        Log.d("SignupDebug", "가져온 임시 토큰: $tempToken")
+
+        if (tempToken.isNullOrBlank()) {
+            return Result.failure(Exception("임시 토큰이 없습니다. 로그인을 다시 시도해주세요."))
+        }
+        userService.checkNickname("Bearer $tempToken",NicknameRequest(nickname))
+            .handleBaseResponse()
+            .getOrThrow()
+    }*/
+    /*suspend fun checkNickname(nickname: String): Result<NicknameResponse?> = runCatching {
+        val tempToken = tokenManager.getTempToken() // <-- runCatching 안으로 이동
+
+        if (tempToken.isNullOrBlank()) {
+            throw Exception("임시 토큰이 없습니다. 로그인을 다시 시도해주세요.")
+        }
+
+        userService.checkNickname("Bearer $tempToken", NicknameRequest(nickname))
+            .handleBaseResponse()
+            .getOrThrow()
+    }*/
     suspend fun checkNickname(nickname: String): Result<NicknameResponse?> = runCatching {
         userService.checkNickname(NicknameRequest(nickname))
             .handleBaseResponse()
             .getOrThrow()
     }
+    /*suspend fun getAliasChoices(): Result<AliasChoiceResponse?> = runCatching {
+        val tempToken = tokenManager.getTempToken()
 
+        Log.d("SignupDebug", "가져온 임시 토큰: $tempToken")
+
+        if (tempToken.isNullOrBlank()) {
+            return Result.failure(Exception("임시 토큰이 없습니다. 로그인을 다시 시도해주세요."))
+        }
+        userService.getAliasChoices("Bearer $tempToken")
+            .handleBaseResponse()
+            .getOrThrow()
+    }*/
     suspend fun getAliasChoices(): Result<AliasChoiceResponse?> = runCatching {
         userService.getAliasChoices()
             .handleBaseResponse()

--- a/app/src/main/java/com/texthip/thip/ui/feed/component/OthersFeedCard.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/component/OthersFeedCard.kt
@@ -13,6 +13,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale

--- a/app/src/main/java/com/texthip/thip/utils/auth/AuthInterceptor.kt
+++ b/app/src/main/java/com/texthip/thip/utils/auth/AuthInterceptor.kt
@@ -11,11 +11,17 @@ class AuthInterceptor @Inject constructor(
     private val tokenManager: TokenManager
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        // 1. 요청에 이미 Authorization 헤더가 있는지 확인합니다.
+        if (originalRequest.header("Authorization") != null) {
+            // 이미 헤더가 있다면, 아무 작업도 하지 않고 그대로 보냅니다.
+            return chain.proceed(originalRequest)
+        }
+
         val appToken = runBlocking { tokenManager.getToken().first() }
         val tempToken = runBlocking { tokenManager.getTempToken() }
-
         val tokenToSend = appToken ?: tempToken
-
         val requestBuilder = chain.request().newBuilder()
 
         if (!tokenToSend.isNullOrBlank()) {


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #116 

<br/>

## 🔎 작업 내용

- Signup 요청 시 Header를 넣어주는데, 토큰 인터셉터와 충돌이 생겨 발생하는 오류였습니다.
- 개발서버에서는 문제 없이 진행되지만, 운영서버에서는 DNS 방화벽에 막혀 이러한 로직이 문제되는 상황이었습니다.
- 인터셉터에 간단한 검증로직을 추가하여 수정했습니다.

 <br/>

## 📸 스크린샷  

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 😢 해결하지 못한 과제
- [] TASK

  <br/>

## 📢 리뷰어들에게
- 참고해야 할 사항들을 적어주세요

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 없음
- 버그 수정
  - 인증 헤더가 중복 추가되던 문제를 해결하여 로그인된 상태의 네트워크 요청 안정성을 개선했습니다.
  - 닉네임 중복 확인/별칭 추천 관련으로 보고된 동작 이상은 코드 정렬로 인한 변경만 있었으며 기능상 영향은 없습니다.
- 개선
  - 필요 없는 요청에는 토큰 삽입을 자동으로 건너뛰도록 인증 흐름을 정리해 신뢰성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->