### PR TITLE
[Refactor] 소셜로그인, 회원가입 관련 오류 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,9 +108,13 @@ dependencies {
     //implementation ("androidx.datastore:datastore-preferences:1.1.1")
 
 // 구글 로그인
-    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-    implementation("com.google.firebase:firebase-auth")
+    //implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
+    //implementation("com.google.firebase:firebase-auth")
     implementation("com.google.android.gms:play-services-auth:21.2.0")
+
+    implementation("androidx.credentials:credentials:1.2.2")
+    implementation("androidx.credentials:credentials-play-services-auth:1.2.2")
+
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,8 +108,6 @@ dependencies {
     //implementation ("androidx.datastore:datastore-preferences:1.1.1")
 
 // 구글 로그인
-    //implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-    //implementation("com.google.firebase:firebase-auth")
     implementation("com.google.android.gms:play-services-auth:21.2.0")
 
     implementation("androidx.credentials:credentials:1.2.2")

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -38,11 +38,11 @@
           }
         },
         {
-          "client_id": "353417813537-lovs0p2tb9kjnjlp493a7098ov0cb2bu.apps.googleusercontent.com",
+          "client_id": "353417813537-ninddce15lovs82nrklf00hr6hbl1bl0.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
             "package_name": "com.texthip.thip",
-            "certificate_hash": "99315de9382f8b2903131eb4ae926a4739803ef1"
+            "certificate_hash": "b77b447ac3b50ede99a93a84e79ca867b984a5fa"
           }
         },
         {

--- a/app/src/main/java/com/texthip/thip/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/AuthRepository.kt
@@ -35,18 +35,6 @@ class AuthRepository @Inject constructor(
         }
     }
     suspend fun loginWithGoogle(idToken: String): Result<AuthResponse?> {
-        /*return runCatching {
-            //Firebase에 구글 ID 토큰으로 로그인
-            val credential = GoogleAuthProvider.getCredential(idToken, null)
-            val authResult = Firebase.auth.signInWithCredential(credential).await()
-            val googleUid = authResult.user?.uid ?: throw IllegalStateException("Google User UID is null")
-
-            //받아온 UID로 신규/기존 유저인지 확인 요청
-            val request = AuthRequest(oauth2Id = "google_$googleUid")
-            authService.checkNewUser(request)
-                .handleBaseResponse()
-                .getOrThrow()
-        }*/
         return runCatching {
             val payload = idToken.split('.')[1]//ID 토큰을 .기준 분리
             val decodedJson = String(Base64.getUrlDecoder().decode(payload))//디코딩 해서 JSON 문자열 반환

--- a/app/src/main/java/com/texthip/thip/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/AuthRepository.kt
@@ -1,9 +1,6 @@
 package com.texthip.thip.data.repository
 
 import android.content.Context
-import com.google.firebase.Firebase
-import com.google.firebase.auth.GoogleAuthProvider
-import com.google.firebase.auth.auth
 import com.kakao.sdk.user.UserApiClient
 import com.texthip.thip.data.model.auth.request.AuthRequest
 import com.texthip.thip.data.model.auth.response.AuthResponse
@@ -11,7 +8,10 @@ import com.texthip.thip.data.model.base.handleBaseResponse
 import com.texthip.thip.data.service.AuthService
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.tasks.await
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.Base64
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
@@ -35,7 +35,7 @@ class AuthRepository @Inject constructor(
         }
     }
     suspend fun loginWithGoogle(idToken: String): Result<AuthResponse?> {
-        return runCatching {
+        /*return runCatching {
             //Firebase에 구글 ID 토큰으로 로그인
             val credential = GoogleAuthProvider.getCredential(idToken, null)
             val authResult = Firebase.auth.signInWithCredential(credential).await()
@@ -43,6 +43,19 @@ class AuthRepository @Inject constructor(
 
             //받아온 UID로 신규/기존 유저인지 확인 요청
             val request = AuthRequest(oauth2Id = "google_$googleUid")
+            authService.checkNewUser(request)
+                .handleBaseResponse()
+                .getOrThrow()
+        }*/
+        return runCatching {
+            val payload = idToken.split('.')[1]//ID 토큰을 .기준 분리
+            val decodedJson = String(Base64.getUrlDecoder().decode(payload))//디코딩 해서 JSON 문자열 반환
+
+            val jsonObject = Json.parseToJsonElement(decodedJson).jsonObject
+            val googleSubId = jsonObject["sub"]?.jsonPrimitive?.content ?: throw IllegalStateException("구글 userID (sub)값이 없습니다.")//sub 값 추출
+
+            //받아온 UID로 신규/기존 유저인지 확인 요청
+            val request = AuthRequest(oauth2Id = "google_$googleSubId")
             authService.checkNewUser(request)
                 .handleBaseResponse()
                 .getOrThrow()

--- a/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageEditScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageEditScreen.kt
@@ -114,7 +114,7 @@ fun EditProfileContent(
                 WarningTextField(
                     containerColor = colors.DarkGrey02,
                     value = uiState.nickname,
-                    onValueChange = onNicknameChange,
+                    onValueChange = { newNickname -> onNicknameChange(newNickname.lowercase()) },
                     hint = stringResource(R.string.nickname_condition),
                     showWarning = uiState.nicknameWarningMessageResId != null,
                     showIcon = false,

--- a/app/src/main/java/com/texthip/thip/ui/mypage/viewmodel/MyPageViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/viewmodel/MyPageViewModel.kt
@@ -71,7 +71,7 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             tokenManager.clearTokens()
             // 2. 카카오 SDK에서 로그아웃
-            UserApiClient.instance.unlink { error ->
+            UserApiClient.instance.logout { error ->
                 if (error != null) {
                     Log.e("MyPageViewModel", "카카오 로그아웃 실패", error)
                 } else {

--- a/app/src/main/java/com/texthip/thip/ui/signin/screen/SignupNicknameScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/signin/screen/SignupNicknameScreen.kt
@@ -100,7 +100,7 @@ fun SignupNicknameContent(
             WarningTextField(
                 containerColor = colors.DarkGrey02,
                 value = nickname,
-                onValueChange = onNicknameChange,
+                onValueChange = { newNickname -> onNicknameChange(newNickname.lowercase()) },//소문자로 즉시 변경
                 hint = stringResource(R.string.nickname_condition),
                 showWarning = warningMessageResId != null,
                 showIcon = false,


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #124 

<br/>

## 🔎 작업 내용

- 카카오 유저가 로그아웃 후 재로그인을 시도하는 경우 
   - 기존 유저임에도 카카오 측에서 사용자에게  권한 동의 등을 얻는 상황이 발생했습니다. 해당 원인 파악 후, unlink 가 아닌 logout으로 처리하도록 수정했습니다

- 카카오 디벨로퍼스 계정을 팀 통합 계정으로 변경 했습니다.

- 구글 유저가 안드로이드로 로그인하는 경우/ 웹으로 로그인 하는 경우 
   - 이 두 경우를 각각 다른 유저로 처리해버리는 오류가 있었습니다.
   - 이는 안드와 웹의 로그인 처리 방식이 달라, provider_id의 형식이 다르게 서버에 전송되어 발생하는 오류였습니다.
   - firebase에서 제공해주는 uid 를 사용하는 기존 방식에서 구글에서 발급해주는 sub 변수에 들어있는 uid를 사용하도록 변경하여 해결했습니다.
 
- 회원가입 시 닉네임 입력의 경우, 대문자가 포함되는 것은 오류로 인식하는데, 입력은 허용되어 있는 오류
    - 사용자가 대문자 입력 시, 바로 소문자로 변경되어 입력되도록 처리했습니다.
    - 닉네임 변경 시에도 동일하게 처리했습니다.

 <br/>

## 📸 스크린샷  

<br/>

## 😢 해결하지 못한 과제

  <br/>

## 📢 리뷰어들에게
- 카카오 네이티브 앱 키 변동사항 있습니다! 카톡으로 보내드리겠습니다 각자 로컬에서 네이티브 앱 키 수정해주세욧

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 닉네임 입력이 실시간 소문자 자동 변환으로 일관성 향상.
- 버그 수정
  - 카카오 로그아웃 처리 안정화(연결 해제 대신 로그아웃 수행)로 로그아웃 신뢰성 개선.
- 리팩터링
  - Google 로그인 연동을 AndroidX Credentials 기반으로 전환하여 인증 흐름 단순화 및 안정성 향상.
- 잡무(Chores)
  - Google OAuth 클라이언트 구성 업데이트.
  - 인증 관련 의존성 정리 및 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->