### PR TITLE
[API] 기록장 기록, 투표 수정

### DIFF
--- a/app/src/main/java/com/texthip/thip/data/model/rooms/request/RoomsPatchRecordRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/request/RoomsPatchRecordRequest.kt
@@ -1,0 +1,8 @@
+package com.texthip.thip.data.model.rooms.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoomsPatchRecordRequest(
+    val content: String
+)

--- a/app/src/main/java/com/texthip/thip/data/model/rooms/request/RoomsPatchVoteRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/request/RoomsPatchVoteRequest.kt
@@ -1,0 +1,8 @@
+package com.texthip.thip.data.model.rooms.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoomsPatchVoteRequest(
+    val content: String,
+)

--- a/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomsPatchRecordResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomsPatchRecordResponse.kt
@@ -1,0 +1,8 @@
+package com.texthip.thip.data.model.rooms.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoomsPatchRecordResponse(
+    val roomId: Int
+)

--- a/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomsPatchVoteResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomsPatchVoteResponse.kt
@@ -1,0 +1,8 @@
+package com.texthip.thip.data.model.rooms.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoomsPatchVoteResponse(
+    val roomId: Int,
+)

--- a/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomsPostsResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomsPostsResponse.kt
@@ -35,6 +35,6 @@ data class PostList(
 data class VoteItems(
     val voteItemId: Int,
     val itemName: String,
-    val percentage: Int,
+    val count: Int,
     val isVoted: Boolean,
 )

--- a/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
@@ -10,6 +10,7 @@ import com.texthip.thip.data.model.rooms.request.RoomSecretRoomRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateDailyGreetingRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateVoteRequest
 import com.texthip.thip.data.model.rooms.request.RoomsPatchRecordRequest
+import com.texthip.thip.data.model.rooms.request.RoomsPatchVoteRequest
 import com.texthip.thip.data.model.rooms.request.RoomsPostsLikesRequest
 import com.texthip.thip.data.model.rooms.request.RoomsRecordRequest
 import com.texthip.thip.data.model.rooms.request.RoomsVoteRequest
@@ -328,6 +329,20 @@ class RoomsRepository @Inject constructor(
             recordId = recordId,
             request = RoomsPatchRecordRequest(
                 content = content
+            )
+        ).handleBaseResponse().getOrThrow()
+    }
+
+    suspend fun patchRoomsVote(
+        roomId: Int,
+        voteId: Int,
+        content: String,
+    ) = runCatching {
+        roomsService.patchRoomsVote(
+            roomId = roomId,
+            voteId = voteId,
+            request = RoomsPatchVoteRequest(
+                content = content,
             )
         ).handleBaseResponse().getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
@@ -9,6 +9,7 @@ import com.texthip.thip.data.model.rooms.request.RoomJoinRequest
 import com.texthip.thip.data.model.rooms.request.RoomSecretRoomRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateDailyGreetingRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateVoteRequest
+import com.texthip.thip.data.model.rooms.request.RoomsPatchRecordRequest
 import com.texthip.thip.data.model.rooms.request.RoomsPostsLikesRequest
 import com.texthip.thip.data.model.rooms.request.RoomsRecordRequest
 import com.texthip.thip.data.model.rooms.request.RoomsVoteRequest
@@ -314,6 +315,20 @@ class RoomsRepository @Inject constructor(
     ) = runCatching {
         roomsService.leaveRoom(
             roomId = roomId,
+        ).handleBaseResponse().getOrThrow()
+    }
+
+    suspend fun patchRoomsRecord(
+        roomId: Int,
+        recordId: Int,
+        content: String
+    ) = runCatching {
+        roomsService.patchRoomsRecord(
+            roomId = roomId,
+            recordId = recordId,
+            request = RoomsPatchRecordRequest(
+                content = content
+            )
         ).handleBaseResponse().getOrThrow()
     }
 }

--- a/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
@@ -6,6 +6,7 @@ import com.texthip.thip.data.model.rooms.request.RoomJoinRequest
 import com.texthip.thip.data.model.rooms.request.RoomSecretRoomRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateDailyGreetingRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateVoteRequest
+import com.texthip.thip.data.model.rooms.request.RoomsPatchRecordRequest
 import com.texthip.thip.data.model.rooms.request.RoomsPostsLikesRequest
 import com.texthip.thip.data.model.rooms.request.RoomsRecordRequest
 import com.texthip.thip.data.model.rooms.request.RoomsVoteRequest
@@ -24,6 +25,7 @@ import com.texthip.thip.data.model.rooms.response.RoomsDailyGreetingResponse
 import com.texthip.thip.data.model.rooms.response.RoomsDeleteDailyGreetingResponse
 import com.texthip.thip.data.model.rooms.response.RoomsDeleteRecordResponse
 import com.texthip.thip.data.model.rooms.response.RoomsDeleteVoteResponse
+import com.texthip.thip.data.model.rooms.response.RoomsPatchRecordResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPlayingResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPostsLikesResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPostsResponse
@@ -35,6 +37,7 @@ import com.texthip.thip.data.model.rooms.response.RoomsVoteResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -195,4 +198,11 @@ interface RoomsService {
     suspend fun leaveRoom(
         @Path("roomId") roomId: Int
     ): BaseResponse<Unit>
+
+    @PATCH("rooms/{roomId}/records/{recordId}")
+    suspend fun patchRoomsRecord(
+        @Path("roomId") roomId: Int,
+        @Path("recordId") recordId: Int,
+        @Body request: RoomsPatchRecordRequest
+    ): BaseResponse<RoomsPatchRecordResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
@@ -7,6 +7,7 @@ import com.texthip.thip.data.model.rooms.request.RoomSecretRoomRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateDailyGreetingRequest
 import com.texthip.thip.data.model.rooms.request.RoomsCreateVoteRequest
 import com.texthip.thip.data.model.rooms.request.RoomsPatchRecordRequest
+import com.texthip.thip.data.model.rooms.request.RoomsPatchVoteRequest
 import com.texthip.thip.data.model.rooms.request.RoomsPostsLikesRequest
 import com.texthip.thip.data.model.rooms.request.RoomsRecordRequest
 import com.texthip.thip.data.model.rooms.request.RoomsVoteRequest
@@ -26,6 +27,7 @@ import com.texthip.thip.data.model.rooms.response.RoomsDeleteDailyGreetingRespon
 import com.texthip.thip.data.model.rooms.response.RoomsDeleteRecordResponse
 import com.texthip.thip.data.model.rooms.response.RoomsDeleteVoteResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPatchRecordResponse
+import com.texthip.thip.data.model.rooms.response.RoomsPatchVoteResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPlayingResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPostsLikesResponse
 import com.texthip.thip.data.model.rooms.response.RoomsPostsResponse
@@ -205,4 +207,11 @@ interface RoomsService {
         @Path("recordId") recordId: Int,
         @Body request: RoomsPatchRecordRequest
     ): BaseResponse<RoomsPatchRecordResponse>
+
+    @PATCH("rooms/{roomId}/votes/{voteId}")
+    suspend fun patchRoomsVote(
+        @Path("roomId") roomId: Int,
+        @Path("voteId") voteId: Int,
+        @Body request: RoomsPatchVoteRequest
+    ): BaseResponse<RoomsPatchVoteResponse>
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/buttons/GroupVoteButton.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/buttons/GroupVoteButton.kt
@@ -39,13 +39,19 @@ fun GroupVoteButton(
     hasVoted: Boolean = false, // 투표 여부
     onOptionSelected: (Int?) -> Unit
 ) {
+    val totalVotes = voteItems.sumOf { it.count }
+
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         voteItems.forEachIndexed { index, item ->
             val isSelected = selectedIndex == index
-            val votePercent = if (hasVoted) item.percentage.coerceIn(0, 100) else 0
+            val votePercent = if (totalVotes > 0) {
+                (item.count.toFloat() / totalVotes * 100).toInt()
+            } else {
+                0
+            }
 
             val animatedPercent by animateFloatAsState(
                 targetValue = votePercent / 100f,
@@ -104,7 +110,7 @@ fun GroupVoteButton(
                     )
                     if (hasVoted) {
                         Text(
-                            text = "${item.percentage}%",
+                            text = "${item.count}표",
                             color = textColor,
                             style = fontStyle
                         )

--- a/app/src/main/java/com/texthip/thip/ui/common/forms/BookPageTextField.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/forms/BookPageTextField.kt
@@ -46,10 +46,12 @@ fun BookPageTextField(
     modifier: Modifier = Modifier,
     bookTotalPage: Int,
     enabled: Boolean = true,
+    readOnly: Boolean = false,
     text: String,
     isError: Boolean,
     onValueChange: (String) -> Unit,
     showClearButton: Boolean = true,
+    showTotalPage: Boolean = true
 ) {
     var hasFocusCleared by remember(text) { mutableStateOf(false) }
     
@@ -62,7 +64,8 @@ fun BookPageTextField(
                 }
             },
             enabled = enabled,
-            visualTransformation = if (enabled) {
+            readOnly = readOnly,
+            visualTransformation = if (showTotalPage) {
                 SuffixTransformation("/${bookTotalPage}p", colors.Grey02)
             } else {
                 VisualTransformation.None
@@ -70,15 +73,21 @@ fun BookPageTextField(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = modifier
                 .size(width = 320.dp, height = 48.dp)
-                .onFocusChanged { focusState ->
-                    if (focusState.isFocused && !hasFocusCleared && text.isNotEmpty()) {
-                        hasFocusCleared = true
-                        onValueChange("")
+                .then(
+                    if (enabled) {
+                        Modifier.onFocusChanged { focusState ->
+                            if (focusState.isFocused && !hasFocusCleared && text.isNotEmpty()) {
+                                hasFocusCleared = true
+                                onValueChange("")
+                            }
+                            if (!focusState.isFocused) {
+                                hasFocusCleared = false
+                            }
+                        }
+                    } else {
+                        Modifier
                     }
-                    if (!focusState.isFocused) {
-                        hasFocusCleared = false
-                    }
-                }
+                )
                 .then(
                     if (isError)
                         Modifier.border(

--- a/app/src/main/java/com/texthip/thip/ui/common/forms/BorderedTextField.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/forms/BorderedTextField.kt
@@ -38,6 +38,7 @@ fun BorderedTextField(
     hint: String,
     text: String,
     canRemove: Boolean = true,
+    isEnabled: Boolean = true,
     onTextChange: (String) -> Unit,
     onDelete: () -> Unit,
     onRemoveField: () -> Unit
@@ -46,11 +47,15 @@ fun BorderedTextField(
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
 
-    val iconRes = when {
-        isFocused && text.isEmpty() -> R.drawable.ic_x_circle_darkgrey
-        isFocused && text.isNotEmpty() -> R.drawable.ic_x_circle_grey
-        !isFocused && canRemove -> R.drawable.ic_delete
-        else -> null
+    val iconRes = if (isEnabled) {
+        when {
+            isFocused && text.isEmpty() -> R.drawable.ic_x_circle_darkgrey
+            isFocused && text.isNotEmpty() -> R.drawable.ic_x_circle_grey
+            !isFocused && canRemove -> R.drawable.ic_delete
+            else -> null
+        }
+    } else {
+        null
     }
 
     val iconEnabled = when (iconRes) {
@@ -74,6 +79,7 @@ fun BorderedTextField(
         BasicTextField(
             value = text,
             onValueChange = onTextChange,
+            enabled = isEnabled,
             textStyle = myStyle.copy(color = colors.White),
             singleLine = true,
             modifier = Modifier

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/OpinionInputSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/OpinionInputSection.kt
@@ -11,9 +11,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
@@ -29,7 +32,8 @@ fun OpinionInputSection(
     textFieldValue: TextFieldValue,
     onTextChange: (TextFieldValue) -> Unit,
     hint: String = stringResource(R.string.my_opinion_placeholder),
-    maxLength: Int = 500
+    maxLength: Int = 500,
+    focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
     val text = textFieldValue.text
 
@@ -52,7 +56,8 @@ fun OpinionInputSection(
                 },
                 textStyle = typography.menu_r400_s14_h24.copy(color = colors.White),
                 modifier = Modifier
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
                 cursorBrush = SolidColor(colors.NeonGreen),
                 decorationBox = { innerTextField ->
                     Box(

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/OpinionInputSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/OpinionInputSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.R
@@ -25,13 +26,12 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 @Composable
 fun OpinionInputSection(
     title: String = stringResource(R.string.my_opinion_title),
-    text: String,
-    onTextChange: (String) -> Unit,
+    textFieldValue: TextFieldValue,
+    onTextChange: (TextFieldValue) -> Unit,
     hint: String = stringResource(R.string.my_opinion_placeholder),
     maxLength: Int = 500
 ) {
-    val isOverLimit = text.length > maxLength
-    val displayCount = if (text.length > maxLength) maxLength else text.length
+    val text = textFieldValue.text
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
@@ -44,9 +44,11 @@ fun OpinionInputSection(
             modifier = Modifier.fillMaxWidth()
         ) {
             BasicTextField(
-                value = text,
-                onValueChange = {
-                    if (it.length <= maxLength) onTextChange(it)
+                value = textFieldValue,
+                onValueChange = { newTextFieldValue ->
+                    if (newTextFieldValue.text.length <= maxLength) {
+                        onTextChange(newTextFieldValue)
+                    }
                 },
                 textStyle = typography.menu_r400_s14_h24.copy(color = colors.White),
                 modifier = Modifier
@@ -74,8 +76,8 @@ fun OpinionInputSection(
             horizontalArrangement = Arrangement.End
         ) {
             Text(
-                text = stringResource(R.string.group_input_count, displayCount, maxLength),
-                color = if (isOverLimit) colors.Red else colors.NeonGreen,
+                text = stringResource(R.string.group_input_count, text.length, maxLength),
+                color = colors.NeonGreen,
                 style = typography.info_r400_s12
             )
         }
@@ -85,10 +87,12 @@ fun OpinionInputSection(
 @Preview
 @Composable
 private fun OpinionInputSectionPreview() {
-    var text by rememberSaveable { mutableStateOf("") }
+    var value by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(""))
+    }
 
     OpinionInputSection(
-        text = text,
-        onTextChange = { text = it }
+        textFieldValue = value,
+        onTextChange = { value = it }
     )
 }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/PageInputSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/PageInputSection.kt
@@ -40,7 +40,8 @@ fun PageInputSection(
     bookTotalPage: Int,
     isEligible: Boolean,
     onInfoClick: () -> Unit,
-    onInfoPositionCaptured: (LayoutCoordinates) -> Unit
+    onInfoPositionCaptured: (LayoutCoordinates) -> Unit,
+    isEnabled: Boolean = true
 ) {
     val allRangeText = stringResource(R.string.all_range)
     val isError = remember(pageText, bookTotalPage, isGeneralReview) {
@@ -71,49 +72,53 @@ fun PageInputSection(
                 onValueChange = {
                     if (!isGeneralReview) onPageTextChange(it)
                 },
-                enabled = !isGeneralReview,
+                enabled = !isGeneralReview && isEnabled,
+                readOnly = !isEnabled,
                 isError = isError,
-                showClearButton = !isGeneralReview
+                showClearButton = !isGeneralReview,
+                showTotalPage = !isGeneralReview
             )
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.BottomEnd),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            if (isEnabled) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomEnd),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_information),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(20.dp)
-                            .onGloballyPositioned { coordinates ->
-                                onInfoPositionCaptured(coordinates)
-                            }
-                            .clickable { onInfoClick() },
-                        tint = colors.Grey02
-                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_information),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(20.dp)
+                                .onGloballyPositioned { coordinates ->
+                                    onInfoPositionCaptured(coordinates)
+                                }
+                                .clickable { onInfoClick() },
+                            tint = colors.Grey02
+                        )
 
-                    Text(
-                        text = stringResource(R.string.general_review),
-                        style = typography.info_r400_s12,
-                        color = colors.Grey
+                        Text(
+                            text = stringResource(R.string.general_review),
+                            style = typography.info_r400_s12,
+                            color = colors.Grey
+                        )
+                    }
+
+                    ToggleSwitchButton(
+                        isChecked = isGeneralReview,
+                        onToggleChange = { checked ->
+                            onGeneralReviewToggle(checked)
+                            onPageTextChange(if (checked) allRangeText else "")
+                        },
+                        enabled = isEligible
                     )
                 }
-
-                ToggleSwitchButton(
-                    isChecked = isGeneralReview,
-                    onToggleChange = { checked ->
-                        onGeneralReviewToggle(checked)
-                        onPageTextChange(if (checked) allRangeText else "")
-                    },
-                    enabled = isEligible
-                )
             }
         }
     }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/VoteInputSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/VoteInputSection.kt
@@ -18,9 +18,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.texthip.thip.R
@@ -30,8 +33,8 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 
 @Composable
 fun VoteInputSection(
-    title: String,
-    onTitleChange: (String) -> Unit,
+    titleValue: TextFieldValue,
+    onTitleChange: (TextFieldValue) -> Unit,
     options: List<String>,
     onOptionChange: (index: Int, newText: String) -> Unit,
     onAddOption: () -> Unit,
@@ -39,7 +42,8 @@ fun VoteInputSection(
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true,
     maxOptionLength: Int = 20,
-    maxOptions: Int = 5
+    maxOptions: Int = 5,
+    focusRequester: FocusRequester = remember { FocusRequester() },
 ) {
     val focusManager = LocalFocusManager.current
 
@@ -55,15 +59,15 @@ fun VoteInputSection(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         BasicTextField(
-            value = title,
-            onValueChange = { if (it.length <= maxOptionLength) onTitleChange(it) },
-//            enabled = isEnabled,
+            value = titleValue,
+            onValueChange = { if (it.text.length <= maxOptionLength) onTitleChange(it) },
             textStyle = typography.smalltitle_m500_s18_h24.copy(color = colors.White),
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
             cursorBrush = SolidColor(colors.NeonGreen),
             decorationBox = { innerTextField ->
-                if (title.isEmpty()) {
+                if (titleValue.text.isEmpty()) {
                     Text(
                         text = stringResource(R.string.vote_title_placeholder),
                         color = colors.Grey02,
@@ -116,12 +120,14 @@ fun VoteInputSection(
 @Preview
 @Composable
 private fun VoteInputSectionPreview() {
-    var title by rememberSaveable { mutableStateOf("") }
+    var value by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(""))
+    }
     var options by rememberSaveable { mutableStateOf(mutableListOf("", "")) }
 
     VoteInputSection(
-        title = title,
-        onTitleChange = { title = it },
+        titleValue = value,
+        onTitleChange = { value = it },
         options = options,
         onOptionChange = { index, newText ->
             options = options.toMutableList().also { it[index] = newText }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/VoteInputSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/VoteInputSection.kt
@@ -37,6 +37,7 @@ fun VoteInputSection(
     onAddOption: () -> Unit,
     onRemoveOption: (index: Int) -> Unit,
     modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
     maxOptionLength: Int = 20,
     maxOptions: Int = 5
 ) {
@@ -45,6 +46,7 @@ fun VoteInputSection(
     Column(
         modifier = modifier
             .clickable(
+                enabled = isEnabled,
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() }
             ) {
@@ -55,6 +57,7 @@ fun VoteInputSection(
         BasicTextField(
             value = title,
             onValueChange = { if (it.length <= maxOptionLength) onTitleChange(it) },
+//            enabled = isEnabled,
             textStyle = typography.smalltitle_m500_s18_h24.copy(color = colors.White),
             modifier = Modifier
                 .fillMaxWidth(),
@@ -81,11 +84,12 @@ fun VoteInputSection(
                 onDelete = { onOptionChange(index, "") }, // x 버튼 클릭 시 내용 삭제
                 onRemoveField = { if (canRemove) onRemoveOption(index) }, // 쓰레기통 클릭 시 항목 제거
                 canRemove = canRemove,
+                isEnabled = isEnabled,
                 hint = stringResource(R.string.vote_content_placeholder)
             )
         }
 
-        if (options.size < maxOptions) {
+        if (options.size < maxOptions && isEnabled) {
             Button(
                 onClick = {
                     focusManager.clearFocus() // 항목 추가 시 포커스 해제

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteCreateScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteCreateScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
@@ -38,6 +39,7 @@ import com.texthip.thip.ui.group.note.viewmodel.GroupNoteCreateUiState
 import com.texthip.thip.ui.group.note.viewmodel.GroupNoteCreateViewModel
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.utils.rooms.advancedImePadding
+import kotlinx.coroutines.delay
 
 @Composable
 fun GroupNoteCreateScreen(
@@ -87,6 +89,15 @@ fun GroupNoteCreateContent(
     // Tooltip 위치 측정용 state
     val iconCoordinates = remember { mutableStateOf<LayoutCoordinates?>(null) }
 
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(uiState.isEditMode) {
+        if (uiState.isEditMode) {
+            delay(100)
+            focusRequester.requestFocus()
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -125,7 +136,8 @@ fun GroupNoteCreateContent(
 
                 OpinionInputSection(
                     textFieldValue = uiState.opinionTextFieldValue,
-                    onTextChange = { onEvent(GroupNoteCreateEvent.OpinionChanged(it)) }
+                    onTextChange = { onEvent(GroupNoteCreateEvent.OpinionChanged(it)) },
+                    focusRequester = focusRequester
                 )
             }
         }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteCreateScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteCreateScreen.kt
@@ -45,6 +45,10 @@ fun GroupNoteCreateScreen(
     recentPage: Int,
     totalPage: Int,
     isOverviewPossible: Boolean,
+    postId: Int?,
+    page: Int?,
+    content: String?,
+    isOverview: Boolean?,
     onBackClick: () -> Unit,
     onNavigateBackWithResult: () -> Unit,
     viewModel: GroupNoteCreateViewModel = hiltViewModel()
@@ -52,7 +56,10 @@ fun GroupNoteCreateScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
-        viewModel.initialize(roomId, recentPage, totalPage, isOverviewPossible)
+        viewModel.initialize(
+            roomId, recentPage, totalPage, isOverviewPossible,
+            postId, page, content, isOverview
+        )
     }
 
     LaunchedEffect(key1 = uiState.isSuccess) {
@@ -87,7 +94,11 @@ fun GroupNoteCreateContent(
     ) {
         Column {
             InputTopAppBar(
-                title = stringResource(R.string.write_record),
+                title = if (uiState.isEditMode) {
+                    stringResource(R.string.edit_record)
+                } else {
+                    stringResource(R.string.write_record)
+                },
                 isRightButtonEnabled = uiState.isFormFilled,
                 onLeftClick = onBackClick,
                 onRightClick = { onEvent(GroupNoteCreateEvent.CreateRecordClicked) }
@@ -108,14 +119,14 @@ fun GroupNoteCreateContent(
                     isEligible = uiState.isOverviewPossible,
                     bookTotalPage = uiState.totalPage,
                     onInfoClick = { showTooltip = true },
-                    onInfoPositionCaptured = { iconCoordinates.value = it }
+                    onInfoPositionCaptured = { iconCoordinates.value = it },
+                    isEnabled = !uiState.isEditMode
                 )
 
                 OpinionInputSection(
-                    text = uiState.opinionText,
+                    textFieldValue = uiState.opinionTextFieldValue,
                     onTextChange = { onEvent(GroupNoteCreateEvent.OpinionChanged(it)) }
                 )
-
             }
         }
         if (showTooltip && iconCoordinates.value != null) {
@@ -154,7 +165,7 @@ fun GroupNoteCreateContent(
 private fun GroupNoteCreateScreenPreview() {
     ThipTheme {
         GroupNoteCreateContent(
-            uiState = GroupNoteCreateUiState(pageText = "123", opinionText = "재미있었다."),
+            uiState = GroupNoteCreateUiState(),
             onEvent = {},
             onBackClick = {}
         )

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteScreen.kt
@@ -78,6 +78,7 @@ fun GroupNoteScreen(
     onCreateNoteClick: (recentPage: Int, totalPage: Int, isOverviewPossible: Boolean) -> Unit,
     onCreateVoteClick: (recentPage: Int, totalPage: Int, isOverviewPossible: Boolean) -> Unit,
     onNavigateToFeedWrite: (pinInfo: RoomsRecordsPinResponse, recordContent: String) -> Unit,
+    onEditNoteClick: (post: PostList) -> Unit = {},
     onNavigateToUserProfile: (userId: Long) -> Unit = {},
     resultTabIndex: Int? = null,
     onResultConsumed: () -> Unit = {},
@@ -153,6 +154,7 @@ fun GroupNoteScreen(
                 onCreateVoteClick(s.recentBookPage, s.totalBookPage, s.isOverviewPossible)
             }
         },
+        onEditNoteClick = onEditNoteClick,
         onNavigateToUserProfile = onNavigateToUserProfile,
         showProgressBar = showProgressBar,
         progress = progress.value
@@ -166,6 +168,7 @@ fun GroupNoteContent(
     onBackClick: () -> Unit,
     onCreateNoteClick: () -> Unit,
     onCreateVoteClick: () -> Unit,
+    onEditNoteClick: (post: PostList) -> Unit,
     onNavigateToUserProfile: (userId: Long) -> Unit,
     showProgressBar: Boolean,
     progress: Float
@@ -511,6 +514,14 @@ fun GroupNoteContent(
         val menuItems = if (post.isWriter) {
             listOf(
                 MenuBottomSheetItem(
+                    text = stringResource(R.string.modify),
+                    color = colors.White,
+                    onClick = {
+                        onEditNoteClick(post)
+                        selectedPostForMenu = null
+                    }
+                ),
+                MenuBottomSheetItem(
                     text = stringResource(R.string.delete),
                     color = colors.Red,
                     onClick = {
@@ -652,7 +663,8 @@ private fun GroupNoteScreenPreview() {
             onCreateVoteClick = {},
             showProgressBar = true,
             progress = 0.5f,
-            onNavigateToUserProfile = {}
+            onNavigateToUserProfile = {},
+            onEditNoteClick = {}
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteScreen.kt
@@ -79,6 +79,7 @@ fun GroupNoteScreen(
     onCreateVoteClick: (recentPage: Int, totalPage: Int, isOverviewPossible: Boolean) -> Unit,
     onNavigateToFeedWrite: (pinInfo: RoomsRecordsPinResponse, recordContent: String) -> Unit,
     onEditNoteClick: (post: PostList) -> Unit = {},
+    onEditVoteClick: (post: PostList) -> Unit = {},
     onNavigateToUserProfile: (userId: Long) -> Unit = {},
     resultTabIndex: Int? = null,
     onResultConsumed: () -> Unit = {},
@@ -155,6 +156,7 @@ fun GroupNoteScreen(
             }
         },
         onEditNoteClick = onEditNoteClick,
+        onEditVoteClick = onEditVoteClick,
         onNavigateToUserProfile = onNavigateToUserProfile,
         showProgressBar = showProgressBar,
         progress = progress.value
@@ -169,6 +171,7 @@ fun GroupNoteContent(
     onCreateNoteClick: () -> Unit,
     onCreateVoteClick: () -> Unit,
     onEditNoteClick: (post: PostList) -> Unit,
+    onEditVoteClick: (post: PostList) -> Unit,
     onNavigateToUserProfile: (userId: Long) -> Unit,
     showProgressBar: Boolean,
     progress: Float
@@ -517,7 +520,10 @@ fun GroupNoteContent(
                     text = stringResource(R.string.modify),
                     color = colors.White,
                     onClick = {
-                        onEditNoteClick(post)
+                        when (post.postType) {
+                            "RECORD" -> onEditNoteClick(post)
+                            "VOTE" -> onEditVoteClick(post)
+                        }
                         selectedPostForMenu = null
                     }
                 ),
@@ -664,7 +670,8 @@ private fun GroupNoteScreenPreview() {
             showProgressBar = true,
             progress = 0.5f,
             onNavigateToUserProfile = {},
-            onEditNoteClick = {}
+            onEditNoteClick = {},
+            onEditVoteClick = {}
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupNoteScreen.kt
@@ -424,7 +424,7 @@ fun GroupNoteContent(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 120.dp)
+                        .padding(top = 98.dp)
                 ) {
                     Box(
                         modifier = Modifier

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupVoteCreateScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupVoteCreateScreen.kt
@@ -18,10 +18,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -38,6 +40,7 @@ import com.texthip.thip.ui.group.note.viewmodel.GroupVoteCreateUiState
 import com.texthip.thip.ui.group.note.viewmodel.GroupVoteCreateViewModel
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.utils.rooms.advancedImePadding
+import kotlinx.coroutines.delay
 
 @Composable
 fun GroupVoteCreateScreen(
@@ -86,6 +89,15 @@ fun GroupVoteCreateContent(
     var showTooltip by rememberSaveable { mutableStateOf(false) }
     val iconCoordinates = remember { mutableStateOf<LayoutCoordinates?>(null) }
 
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(uiState.isEditMode) {
+        if (uiState.isEditMode) {
+            delay(100)
+            focusRequester.requestFocus()
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -120,7 +132,7 @@ fun GroupVoteCreateContent(
                 )
 
                 VoteInputSection(
-                    title = uiState.title,
+                    titleValue = uiState.titleValue,
                     onTitleChange = { onEvent(GroupVoteCreateEvent.TitleChanged(it)) },
                     options = uiState.options,
                     onOptionChange = { index, newText ->
@@ -130,7 +142,8 @@ fun GroupVoteCreateContent(
                     onRemoveOption = { index ->
                         onEvent(GroupVoteCreateEvent.RemoveOptionClicked(index))
                     },
-                    isEnabled = !uiState.isEditMode
+                    isEnabled = !uiState.isEditMode,
+                    focusRequester = focusRequester
                 )
             }
         }
@@ -173,7 +186,7 @@ private fun GroupVoteCreateScreenPreview() {
         GroupVoteCreateContent(
             uiState = GroupVoteCreateUiState(
                 pageText = "123",
-                title = "가장 인상깊은 구절은?",
+                titleValue = TextFieldValue("이번 모임의 장소는 어디가 좋을까요?"),
                 options = listOf("1연 1행", "2연 3행", ""),
                 bookTotalPage = 600,
                 isGeneralReviewEnabled = true

--- a/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupVoteCreateScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/screen/GroupVoteCreateScreen.kt
@@ -45,6 +45,11 @@ fun GroupVoteCreateScreen(
     recentPage: Int,
     totalPage: Int,
     isOverviewPossible: Boolean,
+    postId: Int?,
+    page: Int?,
+    isOverview: Boolean?,
+    title: String?,
+    options: List<String>?,
     onBackClick: () -> Unit,
     onNavigateBackWithResult: () -> Unit,
     viewModel: GroupVoteCreateViewModel = hiltViewModel()
@@ -52,7 +57,10 @@ fun GroupVoteCreateScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.initialize(roomId, recentPage, totalPage, isOverviewPossible)
+        viewModel.initialize(
+            roomId, recentPage, totalPage, isOverviewPossible,
+            postId, page, isOverview, title, options
+        )
     }
 
     LaunchedEffect(uiState.isSuccess) {
@@ -85,7 +93,8 @@ fun GroupVoteCreateContent(
     ) {
         Column {
             InputTopAppBar(
-                title = stringResource(R.string.create_vote),
+                title = if (uiState.isEditMode) stringResource(R.string.edit_vote)
+                else stringResource(R.string.create_vote),
                 isRightButtonEnabled = uiState.isFormFilled,
                 onLeftClick = onBackClick,
                 onRightClick = { onEvent(GroupVoteCreateEvent.CreateVoteClicked) }
@@ -106,7 +115,8 @@ fun GroupVoteCreateContent(
                     isEligible = uiState.isGeneralReviewEnabled,
                     bookTotalPage = uiState.bookTotalPage,
                     onInfoClick = { showTooltip = true },
-                    onInfoPositionCaptured = { iconCoordinates.value = it }
+                    onInfoPositionCaptured = { iconCoordinates.value = it },
+                    isEnabled = !uiState.isEditMode
                 )
 
                 VoteInputSection(
@@ -119,7 +129,8 @@ fun GroupVoteCreateContent(
                     onAddOption = { onEvent(GroupVoteCreateEvent.AddOptionClicked) },
                     onRemoveOption = { index ->
                         onEvent(GroupVoteCreateEvent.RemoveOptionClicked(index))
-                    }
+                    },
+                    isEnabled = !uiState.isEditMode
                 )
             }
         }

--- a/app/src/main/java/com/texthip/thip/ui/group/note/viewmodel/GroupNoteViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/viewmodel/GroupNoteViewModel.kt
@@ -97,11 +97,7 @@ class GroupNoteViewModel @Inject constructor(
             }
         }
 
-        viewModelScope.launch {
-            val postsJob = async { loadPosts(isRefresh = true) }
-            val bookPageJob = async { loadBookPageInfo() }
-            awaitAll(postsJob, bookPageJob)
-        }
+        refreshAllData()
     }
 
     private fun loadBookPageInfo() {
@@ -121,6 +117,14 @@ class GroupNoteViewModel @Inject constructor(
                 .onFailure { throwable ->
                     _uiState.update { it.copy(error = throwable.message) }
                 }
+        }
+    }
+
+    private fun refreshAllData() {
+        viewModelScope.launch {
+            val postsJob = async { loadPosts(isRefresh = true) }
+            val bookPageJob = async { loadBookPageInfo() }
+            awaitAll(postsJob, bookPageJob)
         }
     }
 

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
@@ -124,14 +124,24 @@ fun NavHostController.navigateToGroupVoteCreate(
     roomId: Int,
     recentPage: Int,
     totalPage: Int,
-    isOverviewPossible: Boolean
+    isOverviewPossible: Boolean,
+    postId: Int? = null,
+    page: Int? = null,
+    isOverview: Boolean? = null,
+    title: String? = null,
+    options: List<String>? = null
 ) {
     navigate(
         GroupRoutes.VoteCreate(
             roomId = roomId,
             recentPage = recentPage,
             totalPage = totalPage,
-            isOverviewPossible = isOverviewPossible
+            isOverviewPossible = isOverviewPossible,
+            postId = postId,
+            page = page,
+            isOverview = isOverview,
+            title = title,
+            options = options
         )
     )
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
@@ -99,14 +99,22 @@ fun NavHostController.navigateToGroupNoteCreate(
     roomId: Int,
     recentBookPage: Int,
     totalBookPage: Int,
-    isOverviewPossible: Boolean
+    isOverviewPossible: Boolean,
+    postId: Int? = null,
+    page: Int? = null,
+    content: String? = null,
+    isOverview: Boolean? = null
 ) {
     navigate(
         GroupRoutes.NoteCreate(
             roomId = roomId,
             recentBookPage = recentBookPage,
             totalBookPage = totalBookPage,
-            isOverviewPossible = isOverviewPossible
+            isOverviewPossible = isOverviewPossible,
+            postId = postId,
+            page = page,
+            content = content,
+            isOverview = isOverview
         )
     )
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
@@ -364,6 +364,21 @@ fun NavGraphBuilder.groupNavigation(
                     isOverview = post.isOverview
                 )
             },
+            onEditVoteClick = { post ->
+                val currentState = viewModel.uiState.value
+                navController.navigateToGroupVoteCreate(
+                    roomId = roomId,
+                    recentPage = currentState.recentBookPage,
+                    totalPage = currentState.totalBookPage,
+                    isOverviewPossible = currentState.isOverviewPossible,
+                    // 투표 수정 데이터 전달
+                    postId = post.postId,
+                    page = post.page,
+                    isOverview = post.isOverview,
+                    title = post.content,
+                    options = post.voteItems.map { it.itemName }
+                )
+            },
             onCreateVoteClick = { recentPage, totalPage, isOverviewPossible ->
                 navController.navigateToGroupVoteCreate(
                     roomId = roomId,
@@ -427,6 +442,11 @@ fun NavGraphBuilder.groupNavigation(
             recentPage = route.recentPage,
             totalPage = route.totalPage,
             isOverviewPossible = route.isOverviewPossible,
+            postId = route.postId,
+            page = route.page,
+            isOverview = route.isOverview,
+            title = route.title,
+            options = route.options,
             onBackClick = { navigateBack() },
             onNavigateBackWithResult = {
                 // 투표 생성 후 '내 기록' 탭으로 이동

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
@@ -351,6 +351,19 @@ fun NavGraphBuilder.groupNavigation(
                     isOverviewPossible = isOverviewPossible
                 )
             },
+            onEditNoteClick = { post ->
+                val currentState = viewModel.uiState.value
+                navController.navigateToGroupNoteCreate(
+                    roomId = roomId,
+                    recentBookPage = currentState.recentBookPage,
+                    totalBookPage = currentState.totalBookPage,
+                    isOverviewPossible = currentState.isOverviewPossible,
+                    postId = post.postId,
+                    page = post.page,
+                    content = post.content,
+                    isOverview = post.isOverview
+                )
+            },
             onCreateVoteClick = { recentPage, totalPage, isOverviewPossible ->
                 navController.navigateToGroupVoteCreate(
                     roomId = roomId,
@@ -389,6 +402,10 @@ fun NavGraphBuilder.groupNavigation(
             recentPage = route.recentBookPage,
             totalPage = route.totalBookPage,
             isOverviewPossible = route.isOverviewPossible,
+            postId = route.postId,
+            page = route.page,
+            content = route.content,
+            isOverview = route.isOverview,
             onBackClick = {
                 navigateBack()
             },

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
@@ -60,6 +60,11 @@ sealed class GroupRoutes : Routes() {
         val roomId: Int,
         val recentPage: Int,
         val totalPage: Int,
-        val isOverviewPossible: Boolean
+        val isOverviewPossible: Boolean,
+        val postId: Int? = null,
+        val page: Int? = null,
+        val isOverview: Boolean? = null,
+        val title: String? = null,
+        val options: List<String>? = null
     )
 }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
@@ -48,7 +48,11 @@ sealed class GroupRoutes : Routes() {
         val roomId: Int,
         val recentBookPage: Int,
         val totalBookPage: Int,
-        val isOverviewPossible: Boolean
+        val isOverviewPossible: Boolean,
+        val postId: Int? = null,
+        val page: Int? = null,
+        val content: String? = null,
+        val isOverview: Boolean? = null
     )
 
     @Serializable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="character_relationship">인물관계도 보기</string>
     <string name="write_record">기록 작성</string>
     <string name="create_vote">투표 생성</string>
+    <string name="edit_record">기록 수정</string>
+    <string name="edit_vote">투표 수정</string>
 
     <!--    카드 컴포넌트    -->
     <string name="time_ago">시간 전</string>


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #133 

<br/>

## 🔎 작업 내용

- 기록 수정 api를 연결했습니다
- 투표 수정 api를 연결했습니다

 <br/>

## 📸 스크린샷  

### 투표 수정
https://github.com/user-attachments/assets/9504ad6b-e597-4ffe-a177-b9683500dce3

### 기록 수정


https://github.com/user-attachments/assets/1a72c496-1b4e-4df5-97bc-e76bd3da2473


<br/>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 그룹 기록/투표 수정 지원: 기존 내용·페이지·개요·제목·옵션을 사전 채움.
  - 네비게이션 인자 확장으로 수정 흐름 연결 강화.
- UI
  - 투표 표시 개선: 퍼센트 대신 득표수 노출, 진행바는 비율로 애니메이션.
  - 입력 필드 개선: 읽기 전용/비활성 상태 지원, 총 페이지 표시 토글 추가.
  - 제목·의견 입력이 TextFieldValue로 전환되어 커서/포커스 보존 및 자동 포커스.
  - 작성/수정 모드에 따른 상단 타이틀(“기록 수정”/“투표 수정”) 적용.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->