### PR TITLE
[REFACTOR] 완료된 모임방 구현, 모임방 사용성 개선작업

### DIFF
--- a/app/src/main/java/com/texthip/thip/data/model/rooms/response/JoinedRoomListResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/response/JoinedRoomListResponse.kt
@@ -18,6 +18,7 @@ data class JoinedRoomResponse(
     @SerialName("bookImageUrl") val bookImageUrl: String?,
     @SerialName("roomTitle") val roomTitle: String,
     @SerialName("memberCount") val memberCount: Int,
-    @SerialName("userPercentage") val userPercentage: Int
+    @SerialName("userPercentage") val userPercentage: Int,
+    @SerialName("deadlineDate") val deadlineDate: String? = null,
 )
 

--- a/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomMainResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/rooms/response/RoomMainResponse.kt
@@ -17,5 +17,6 @@ data class RoomMainResponse(
 @Serializable
 data class RoomMainList(
     @SerialName("deadlineRoomList") val deadlineRoomList: List<RoomMainResponse> = emptyList(),
-    @SerialName("popularRoomList") val popularRoomList: List<RoomMainResponse> = emptyList()
+    @SerialName("popularRoomList") val popularRoomList: List<RoomMainResponse> = emptyList(),
+    @SerialName("recentRoomList") val recentRoomList: List<RoomMainResponse> = emptyList()
 )

--- a/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
@@ -57,7 +57,7 @@ class RoomsRepository @Inject constructor(
         response
     }
 
-    /** 카테고리별 모임방 섹션 조회 (마감임박/인기) */
+    /** 카테고리별 모임방 섹션 조회 (마감임박/인기/최근 생성) */
     suspend fun getRoomSections(
         genre: Genre? = null
     ): Result<RoomMainList?> = runCatching {

--- a/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/RoomsRepository.kt
@@ -141,11 +141,12 @@ class RoomsRepository @Inject constructor(
     suspend fun searchRooms(
         keyword: String,
         category: String,
+        isAllCategory: Boolean = false,
         sort: String = "deadline",
         isFinalized: Boolean = false,
         cursor: String? = null
     ): Result<RoomsSearchResponse?> = runCatching {
-        roomsService.searchRooms(keyword, category, sort, isFinalized, cursor)
+        roomsService.searchRooms(keyword, category, isAllCategory, sort, isFinalized, cursor)
             .handleBaseResponse()
             .getOrThrow()
     }

--- a/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
@@ -100,6 +100,7 @@ interface RoomsService {
     suspend fun searchRooms(
         @Query("keyword") keyword: String,
         @Query("category") category: String,
+        @Query("isAllCategory") isAllCategory: Boolean = false,
         @Query("sort") sort: String = "deadline",
         @Query("isFinalized") isFinalized: Boolean = false,
         @Query("cursor") cursor: String? = null

--- a/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
@@ -52,7 +52,7 @@ interface RoomsService {
         @Query("cursor") cursor: String? = null
     ): BaseResponse<JoinedRoomListResponse>
 
-    /** 카테고리별 모임방 목록 조회 (마감임박/인기) */
+    /** 카테고리별 모임방 목록 조회 (마감임박/인기/최근 생성) */
     @GET("rooms")
     suspend fun getRooms(
         @Query("category") category: String = "문학"

--- a/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/RoomsService.kt
@@ -108,7 +108,7 @@ interface RoomsService {
 
 
     /** 기록장 API들 */
-    @GET("rooms/{roomId}/playing")
+    @GET("rooms/{roomId}")
     suspend fun getRoomsPlaying(
         @Path("roomId") roomId: Int
     ): BaseResponse<RoomsPlayingResponse>

--- a/app/src/main/java/com/texthip/thip/ui/feed/component/MySubscribelistBar.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/component/MySubscribelistBar.kt
@@ -131,21 +131,25 @@ fun MySubscribeBarlist(
 }
 
 @Composable
-private fun EmptyMySubscriptionBar() {
+fun EmptyMySubscriptionBar(
+    modifier: Modifier = Modifier,
+    text: String = stringResource(R.string.find_thip_mate),
+    onClick: () -> Unit = {}
+) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .padding(top = 8.dp)
             .fillMaxWidth()
             .height(42.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(colors.DarkGrey02)
-            .clickable { }
+            .clickable { onClick() }
     ) {
         Text(
             modifier = Modifier
                 .align(Alignment.CenterStart)
                 .padding(start = 12.dp),
-            text = stringResource(R.string.find_thip_mate),
+            text = text,
             color = colors.White,
             style = typography.view_m500_s12_h20
         )

--- a/app/src/main/java/com/texthip/thip/ui/group/done/screen/GroupDoneScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/done/screen/GroupDoneScreen.kt
@@ -37,6 +37,7 @@ import com.texthip.thip.utils.rooms.RoomUtils
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GroupDoneScreen(
+    onRoomClick: (Int) -> Unit = {},
     onNavigateBack: () -> Unit = {},
     viewModel: GroupDoneViewModel = hiltViewModel()
 ) {
@@ -44,6 +45,7 @@ fun GroupDoneScreen(
 
     GroupDoneContent(
         uiState = uiState,
+        onRoomClick = onRoomClick,
         onNavigateBack = onNavigateBack,
         onRefresh = { viewModel.refreshData() },
         onLoadMore = { viewModel.loadMoreExpiredRooms() }
@@ -54,6 +56,7 @@ fun GroupDoneScreen(
 @Composable
 fun GroupDoneContent(
     uiState: GroupDoneUiState,
+    onRoomClick: (Int) -> Unit = {},
     onNavigateBack: () -> Unit = {},
     onRefresh: () -> Unit = {},
     onLoadMore: () -> Unit = {}
@@ -118,7 +121,7 @@ fun GroupDoneContent(
                             maxParticipants = room.recruitCount, // 모집 인원 수 사용
                             isRecruiting = RoomUtils.isRecruitingByType(room.type),
                             isSecret = !room.isPublic,
-                            onClick = { /* 완료된 모임방은 클릭 불가 */ }
+                            onClick = { onRoomClick(room.roomId) }
                         )
                     }
                 }

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupDeadlineRoomSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupDeadlineRoomSection.kt
@@ -84,9 +84,11 @@ fun GroupRoomDeadlineSection(
                 ),
             )
 
+            val actualPageCount = roomSections.size
+
             val effectivePagerState = rememberPagerState(
-                initialPage = 0,
-                pageCount = { roomSections.size }
+                initialPage = 2,
+                pageCount = { Int.MAX_VALUE }
             )
 
             HorizontalPager(
@@ -95,7 +97,8 @@ fun GroupRoomDeadlineSection(
                 pageSpacing = pageSpacing,
                 modifier = Modifier.fillMaxWidth()
             ) { page ->
-                val (sectionTitle, rooms) = roomSections[page]
+                val actualPage = page % actualPageCount
+                val (sectionTitle, rooms) = roomSections[actualPage]
 
                 val isCurrent = effectivePagerState.currentPage == page
                 val scale = if (isCurrent) 1f else 0.94f

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupDeadlineRoomSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupDeadlineRoomSection.kt
@@ -68,7 +68,7 @@ fun GroupRoomDeadlineSection(
             // Genre enum을 현지화된 문자열로 변환
             val genreStrings = Genre.entries.toDisplayStrings()
 
-            // 마감 임박 방 목록과 인기 방 목록을 섹션으로 구성
+            // 마감 임박 방 목록, 인기 방 목록, 최신 생성 모임방을 섹션으로 구성
             val roomSections = listOf(
                 Pair(
                     stringResource(R.string.room_section_deadline),
@@ -77,7 +77,11 @@ fun GroupRoomDeadlineSection(
                 Pair(
                     stringResource(R.string.room_section_popular),
                     roomMainList?.popularRoomList ?: emptyList()
-                )
+                ),
+                Pair(
+                    stringResource(R.string.room_section_recent),
+                    roomMainList?.recentRoomList ?: emptyList()
+                ),
             )
 
             val effectivePagerState = rememberPagerState(

--- a/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupMainCard.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/myroom/component/GroupMainCard.kt
@@ -105,7 +105,7 @@ fun GroupMainCard(
                         )
                         Spacer(Modifier.width(2.dp))
 
-                        Row (
+                        Row(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
@@ -122,23 +122,39 @@ fun GroupMainCard(
                     }
                     Spacer(Modifier.height(16.dp))
                     // 닉네임 + 진행도
-                    Row(verticalAlignment = Alignment.Bottom) {
-                        Text(
-                            text = stringResource(R.string.group_progress, userName),
-                            color = colors.Grey02,
-                            style = typography.view_m500_s14
-                        )
-                        Spacer(Modifier.width(4.dp))
-                        Text(
-                            text = "${data.userPercentage}",
-                            color = colors.Purple,
-                            style = typography.smalltitle_sb600_s16_h20
-                        )
-                        Text(
-                            text = "%",
-                            color = colors.Purple,
-                            style = typography.menu_sb600_s12,
-                        )
+                    if (data.deadlineDate == null) {
+                        Row(verticalAlignment = Alignment.Bottom) {
+                            Text(
+                                text = stringResource(R.string.group_progress, userName),
+                                color = colors.Grey02,
+                                style = typography.view_m500_s14
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text = "${data.userPercentage}",
+                                color = colors.Purple,
+                                style = typography.smalltitle_sb600_s16_h20
+                            )
+                            Text(
+                                text = "%",
+                                color = colors.Purple,
+                                style = typography.menu_sb600_s12,
+                            )
+                        }
+                    } else {
+                        Row(verticalAlignment = Alignment.Bottom) {
+                            Text(
+                                text = stringResource(R.string.until_start),
+                                color = colors.Grey02,
+                                style = typography.view_m500_s14
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text = data.deadlineDate,
+                                color = colors.Purple,
+                                style = typography.smalltitle_sb600_s16_h20
+                            )
+                        }
                     }
                     Spacer(Modifier.height(10.dp))
 
@@ -153,7 +169,10 @@ fun GroupMainCard(
                             modifier = Modifier
                                 .fillMaxWidth(fraction = percentage / 100f)
                                 .fillMaxHeight()
-                                .background(color = colors.Purple, shape = RoundedCornerShape(12.dp))
+                                .background(
+                                    color = colors.Purple,
+                                    shape = RoundedCornerShape(12.dp)
+                                )
                         )
                     }
                     Spacer(Modifier.height(2.dp))

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/CommentBottomSheet.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/CommentBottomSheet.kt
@@ -139,7 +139,8 @@ fun CommentBottomSheet(
                                     selectedCommentForMenu = comment
                                 },
                                 onReplyLongPress = { reply -> selectedReplyForMenu = reply },
-                                onProfileClick = onProfileClick
+                                onProfileClick = onProfileClick,
+                                onShowToast = onShowToast
                             )
                         }
                     }
@@ -237,7 +238,8 @@ private fun CommentLazyList(
     onEvent: (CommentsEvent) -> Unit,
     onCommentLongPress: (CommentList) -> Unit,
     onReplyLongPress: (ReplyList) -> Unit,
-    onProfileClick: (userId: Long) -> Unit
+    onProfileClick: (userId: Long) -> Unit,
+    onShowToast: (String) -> Unit
 ) {
     val isScrolledToEnd by remember {
         derivedStateOf {
@@ -268,11 +270,13 @@ private fun CommentLazyList(
         ) { comment ->
             CommentSection(
                 commentItem = comment,
+                isExpired = isExpired,
                 onReplyClick = onReplyClick,
                 onEvent = onEvent,
                 onCommentLongPress = onCommentLongPress,
                 onReplyLongPress = onReplyLongPress,
-                onProfileClick = onProfileClick
+                onProfileClick = onProfileClick,
+                onShowToast = onShowToast
             )
         }
 

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/CommentBottomSheet.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/CommentBottomSheet.kt
@@ -51,6 +51,7 @@ import com.texthip.thip.utils.rooms.advancedImePadding
 @Composable
 fun CommentBottomSheet(
     uiState: CommentsUiState,
+    isExpired: Boolean = false,
     onDismiss: () -> Unit,
     onProfileClick: (userId: Long) -> Unit = {},
     onShowToast: (String) -> Unit = {},
@@ -122,6 +123,7 @@ fun CommentBottomSheet(
                         } else {
                             CommentLazyList(
                                 listState = listState,
+                                isExpired = isExpired,
                                 commentList = uiState.comments,
                                 isLoadingMore = uiState.isLoadingMore,
                                 isLastPage = uiState.isLast,
@@ -143,31 +145,33 @@ fun CommentBottomSheet(
                     }
                 }
 
-                CommentTextField(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester),
-                    hint = stringResource(R.string.reply_to),
-                    input = inputText,
-                    onInputChange = { inputText = it },
-                    onSendClick = {
-                        viewModel.onEvent(
-                            CommentsEvent.CreateComment(
-                                content = inputText,
-                                parentId = replyingToCommentId
+                if (!isExpired) {
+                    CommentTextField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester),
+                        hint = stringResource(R.string.reply_to),
+                        input = inputText,
+                        onInputChange = { inputText = it },
+                        onSendClick = {
+                            viewModel.onEvent(
+                                CommentsEvent.CreateComment(
+                                    content = inputText,
+                                    parentId = replyingToCommentId
+                                )
                             )
-                        )
-                        inputText = ""
-                        replyingToCommentId = null
-                        replyingToNickname = null
-                        focusManager.clearFocus()
-                    },
-                    replyTo = replyingToNickname,
-                    onCancelReply = {
-                        replyingToCommentId = null
-                        replyingToNickname = null
-                    }
-                )
+                            inputText = ""
+                            replyingToCommentId = null
+                            replyingToNickname = null
+                            focusManager.clearFocus()
+                        },
+                        replyTo = replyingToNickname,
+                        onCancelReply = {
+                            replyingToCommentId = null
+                            replyingToNickname = null
+                        }
+                    )
+                }
             }
         }
     }
@@ -224,6 +228,7 @@ fun CommentBottomSheet(
 @Composable
 private fun CommentLazyList(
     listState: LazyListState,
+    isExpired: Boolean = false,
     commentList: List<CommentList>,
     isLoadingMore: Boolean,
     isLastPage: Boolean,

--- a/app/src/main/java/com/texthip/thip/ui/group/note/component/CommentSection.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/note/component/CommentSection.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.texthip.thip.R
 import com.texthip.thip.data.model.comments.response.CommentList
 import com.texthip.thip.data.model.comments.response.ReplyList
 import com.texthip.thip.ui.group.note.viewmodel.CommentsEvent
@@ -18,12 +20,16 @@ import com.texthip.thip.ui.theme.ThipTheme
 @Composable
 fun CommentSection(
     commentItem: CommentList,
+    isExpired: Boolean = false,
     onReplyClick: (commentId: Int, nickname: String?) -> Unit,
     onEvent: (CommentsEvent) -> Unit = { _ -> },
     onCommentLongPress: (CommentList) -> Unit = { _ -> },
     onReplyLongPress: (ReplyList) -> Unit = { _ -> },
     onProfileClick: (userId: Long) -> Unit = {},
+    onShowToast: (String) -> Unit = {}
 ) {
+    val expiredRoomMessage = stringResource(R.string.expired_room_read_only_message)
+
     Box {
         Column(
             modifier = Modifier
@@ -35,20 +41,30 @@ fun CommentSection(
             CommentItem(
                 data = commentItem,
                 onReplyClick = {
-                    // commentId가 null이 아닐 때만 답글 달기 가능
-                    // todo: 수정 가능
-                    commentItem.commentId?.let { id ->
-                        onReplyClick(id, commentItem.creatorNickname)
+                    if (isExpired) {
+                        onShowToast(expiredRoomMessage)
+                    } else {
+                        commentItem.commentId?.let { id ->
+                            onReplyClick(id, commentItem.creatorNickname)
+                        }
                     }
                 },
                 onLikeClick = {
-                    // commentId가 null이 아닐 때만 좋아요 가능
-                    // todo: 수정 가능
-                    commentItem.commentId?.let { id ->
-                        onEvent(CommentsEvent.LikeComment(id))
+                    if (isExpired) {
+                        onShowToast(expiredRoomMessage)
+                    } else {
+                        commentItem.commentId?.let { id ->
+                            onEvent(CommentsEvent.LikeComment(id))
+                        }
                     }
                 },
-                onLongPress = { onCommentLongPress(commentItem) },
+                onLongPress = {
+                    if (isExpired) {
+                        onShowToast(expiredRoomMessage)
+                    } else {
+                        onCommentLongPress(commentItem)
+                    }
+                },
 
                 onProfileClick = {
                     commentItem.creatorId?.let { id -> onProfileClick(id) }
@@ -59,14 +75,28 @@ fun CommentSection(
                 ReplyItem(
                     data = reply,
                     onReplyClick = {
-                        commentItem.commentId?.let { parentId ->
-                            onReplyClick(parentId, reply.creatorNickname)
+                        if (isExpired) {
+                            onShowToast(expiredRoomMessage)
+                        } else {
+                            commentItem.commentId?.let { parentId ->
+                                onReplyClick(parentId, reply.creatorNickname)
+                            }
                         }
                     },
                     onLikeClick = {
-                        onEvent(CommentsEvent.LikeReply(reply.commentId))
+                        if (isExpired) {
+                            onShowToast(expiredRoomMessage)
+                        } else {
+                            onEvent(CommentsEvent.LikeReply(reply.commentId))
+                        }
                     },
-                    onLongPress = { onReplyLongPress(reply) },
+                    onLongPress = {
+                        if (isExpired) {
+                            onShowToast(expiredRoomMessage)
+                        } else {
+                            onReplyLongPress(reply)
+                        }
+                    },
                     onProfileClick = { onProfileClick(reply.creatorId) }
                 )
             }

--- a/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/room/screen/GroupRoomScreen.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun GroupRoomScreen(
     roomId: Int,
+    isExpired: Boolean = false,
     onBackClick: () -> Unit = {},
     onNavigateToMates: () -> Unit = {},
     onNavigateToChat: () -> Unit = {},
@@ -96,6 +97,7 @@ fun GroupRoomScreen(
             // 성공 시, 실제 데이터를 화면에 표시
             GroupRoomContent(
                 roomDetails = state.roomsPlaying,
+                isExpired = isExpired,
                 onBackClick = onBackClick,
                 onNavigateToMates = onNavigateToMates,
                 onNavigateToChat = onNavigateToChat,
@@ -109,7 +111,7 @@ fun GroupRoomScreen(
 
         is GroupRoomUiState.Error -> {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(text = state.message, color = colors.White) // TODO: 에러 메시지 스타일링
+                Text(text = state.message, color = colors.White)
             }
         }
     }
@@ -119,6 +121,7 @@ fun GroupRoomScreen(
 @Composable
 fun GroupRoomContent(
     roomDetails: RoomsPlayingResponse,
+    isExpired: Boolean = false,
     onBackClick: () -> Unit = {},
     onNavigateToMates: () -> Unit = {},
     onNavigateToChat: () -> Unit = {},
@@ -228,7 +231,8 @@ fun GroupRoomContent(
 
         GradationTopAppBar(
             onLeftClick = onBackClick,
-            isRightIconVisible = true,
+//            isRightIconVisible = true,
+            isRightIconVisible = !isExpired || !isOwner, // TODO: 방 삭제 기능 추가 시 변경
             onRightClick = { isBottomSheetVisible = true },
         )
 

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -34,6 +35,7 @@ import com.texthip.thip.data.model.rooms.response.RoomMainResponse
 import com.texthip.thip.ui.common.buttons.FloatingButton
 import com.texthip.thip.ui.common.modal.ToastWithDate
 import com.texthip.thip.ui.common.topappbar.LogoTopAppBar
+import com.texthip.thip.ui.feed.component.EmptyMySubscriptionBar
 import com.texthip.thip.ui.group.myroom.component.GroupMySectionHeader
 import com.texthip.thip.ui.group.myroom.component.GroupPager
 import com.texthip.thip.ui.group.myroom.component.GroupRoomDeadlineSection
@@ -95,7 +97,7 @@ fun GroupContent(
     onHideToast: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
-    
+
     // 탭 전환 시 스크롤을 맨 위로 초기화
     LaunchedEffect(Unit) {
         scrollState.scrollTo(0)
@@ -144,6 +146,14 @@ fun GroupContent(
                         .fillMaxWidth()
                         .background(color = colors.DarkGrey02)
                 )
+
+                EmptyMySubscriptionBar(
+                    modifier = Modifier.padding(horizontal = 30.dp),
+                    text = stringResource(R.string.look_around_all_rooms),
+                    onClick = {} // TODO: 전체 모임방 화면으로 이동
+                )
+
+                Spacer(Modifier.height(32.dp))
 
                 // 마감 임박한 독서 모임방
                 GroupRoomDeadlineSection(

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -55,7 +55,8 @@ fun GroupScreen(
     onNavigateToGroupSearch: () -> Unit = {},   // 검색 화면으로 이동
     onNavigateToGroupMy: () -> Unit = {},   // 내 모임방 화면으로 이동
     onNavigateToGroupRecruit: (Int) -> Unit = {},   // 모집 중인 모임방 화면으로 이동
-    onNavigateToGroupRoom: (Int) -> Unit = {},  // 기록장 화면으로 이동
+    onNavigateToGroupRoom: (Int) -> Unit = {},  // 기록장 화면으로 이동,
+    onNavigateToGroupSearchAllRooms: () -> Unit = {},
     viewModel: GroupViewModel = hiltViewModel()
 ) {
     // 화면 재진입 시 데이터 새로고침
@@ -73,10 +74,11 @@ fun GroupScreen(
         onNavigateToGroupMy = onNavigateToGroupMy,
         onNavigateToGroupRecruit = onNavigateToGroupRecruit,
         onNavigateToGroupRoom = onNavigateToGroupRoom,
+        onNavigateToGroupSearchAllRooms = onNavigateToGroupSearchAllRooms,
         onRefreshGroupData = { viewModel.refreshGroupData() },
         onCardVisible = { cardIndex -> viewModel.loadMoreGroups() },
         onSelectGenre = { genreIndex -> viewModel.selectGenre(genreIndex) },
-        onHideToast = { viewModel.hideToast() }
+        onHideToast = { viewModel.hideToast() },
     )
 }
 
@@ -91,6 +93,7 @@ fun GroupContent(
     onNavigateToGroupMy: () -> Unit = {},
     onNavigateToGroupRecruit: (Int) -> Unit = {},
     onNavigateToGroupRoom: (Int) -> Unit = {},
+    onNavigateToGroupSearchAllRooms: () -> Unit = {},
     onRefreshGroupData: () -> Unit = {},
     onCardVisible: (Int) -> Unit = {},
     onSelectGenre: (Int) -> Unit = {},
@@ -150,7 +153,7 @@ fun GroupContent(
                 EmptyMySubscriptionBar(
                     modifier = Modifier.padding(horizontal = 30.dp),
                     text = stringResource(R.string.look_around_all_rooms),
-                    onClick = {} // TODO: 전체 모임방 화면으로 이동
+                    onClick = onNavigateToGroupSearchAllRooms
                 )
 
                 Spacer(Modifier.height(32.dp))

--- a/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupFilteredSearchResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupFilteredSearchResult.kt
@@ -45,14 +45,36 @@ fun GroupFilteredSearchResult(
     onRoomClick: (SearchRoomItem) -> Unit = {},
     canLoadMore: Boolean = false,
     isLoadingMore: Boolean = false,
-    onLoadMore: () -> Unit = {}
+    onLoadMore: () -> Unit = {},
+    isAllCategory: Boolean = false
 ) {
+    val allChipText = stringResource(id = R.string.all)
+    val chipList = remember(genres) { listOf(allChipText) + genres }
+
+    val finalSelectedIndex = if (selectedGenreIndex != -1) {
+        // 특정 장르가 선택되었다면, '전체' 칩 때문에 +1 된 인덱스를 사용
+        selectedGenreIndex + 1
+    } else {
+        // 특정 장르가 선택되지 않았다면, '전체' 칩(인덱스 0)을 선택
+        0
+    }
+
+
     Column {
         GenreChipRow(
             modifier = Modifier.width(12.dp),
-            genres = genres,
-            selectedIndex = selectedGenreIndex,
-            onSelect = onGenreSelect
+            genres = chipList,
+            selectedIndex = finalSelectedIndex,
+            onSelect = { newIndex ->
+                when (newIndex) {
+                    // 칩 선택이 해제된 경우 (동일 칩 재클릭)
+                    -1 -> onGenreSelect(-1)
+                    // '전체' 칩이 선택된 경우 -> 장르 필터 해제
+                    0 -> onGenreSelect(-1)
+                    // 특정 장르가 선택된 경우 -> 원래 인덱스로 변환하여 전달
+                    else -> onGenreSelect(newIndex - 1)
+                }
+            }
         )
         Spacer(modifier = Modifier.height(20.dp))
 

--- a/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupFilteredSearchResult.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupFilteredSearchResult.kt
@@ -46,7 +46,6 @@ fun GroupFilteredSearchResult(
     canLoadMore: Boolean = false,
     isLoadingMore: Boolean = false,
     onLoadMore: () -> Unit = {},
-    isAllCategory: Boolean = false
 ) {
     val allChipText = stringResource(id = R.string.all)
     val chipList = remember(genres) { listOf(allChipText) + genres }

--- a/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupRecentSearch.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupRecentSearch.kt
@@ -35,7 +35,8 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 fun GroupRecentSearch(
     recentSearches: List<String>,
     onSearchClick: (String) -> Unit,
-    onRemove: (String) -> Unit
+    onRemove: (String) -> Unit,
+    onViewAllRoomsClick: () -> Unit = {}
 ) {
     Column {
         Text(
@@ -72,7 +73,7 @@ fun GroupRecentSearch(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable {
-                    // TODO: 전체 방 둘러보기 클릭 시 동작
+                    onViewAllRoomsClick()
                 },
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween

--- a/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupRecentSearch.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/component/GroupRecentSearch.kt
@@ -1,20 +1,27 @@
 package com.texthip.thip.ui.group.search.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,6 +64,30 @@ fun GroupRecentSearch(
                     )
                 }
             }
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    // TODO: 전체 방 둘러보기 클릭 시 동작
+                },
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = stringResource(R.string.look_around_all_rooms_title),
+                color = colors.White,
+                style = typography.smalltitle_sb600_s18_h24
+            )
+
+            Icon(
+                painter = painterResource(R.drawable.ic_chevron),
+                contentDescription = null,
+                tint = Color.Unspecified
+            )
         }
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/group/search/screen/GroupSearchScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/screen/GroupSearchScreen.kt
@@ -28,10 +28,10 @@ import com.texthip.thip.data.model.rooms.response.SearchRoomItem
 import com.texthip.thip.ui.common.buttons.FilterButton
 import com.texthip.thip.ui.common.forms.SearchBookTextField
 import com.texthip.thip.ui.common.topappbar.DefaultTopAppBar
-import com.texthip.thip.ui.group.search.component.GroupRecentSearch
 import com.texthip.thip.ui.group.search.component.GroupEmptyResult
 import com.texthip.thip.ui.group.search.component.GroupFilteredSearchResult
 import com.texthip.thip.ui.group.search.component.GroupLiveSearchResult
+import com.texthip.thip.ui.group.search.component.GroupRecentSearch
 import com.texthip.thip.ui.group.search.viewmodel.GroupSearchUiState
 import com.texthip.thip.ui.group.search.viewmodel.GroupSearchViewModel
 import com.texthip.thip.ui.theme.ThipTheme
@@ -56,7 +56,8 @@ fun GroupSearchScreen(
         onDeleteRecentSearch = viewModel::deleteRecentSearchByKeyword,
         onLoadMoreRooms = viewModel::loadMoreRooms,
         onUpdateSelectedGenre = viewModel::updateSelectedGenre,
-        onUpdateSortType = viewModel::updateSortType
+        onUpdateSortType = viewModel::updateSortType,
+        onViewAllRooms = viewModel::onViewAllRooms
     )
 }
 
@@ -71,7 +72,8 @@ private fun GroupSearchContent(
     onDeleteRecentSearch: (String) -> Unit = {},
     onLoadMoreRooms: () -> Unit = {},
     onUpdateSelectedGenre: (Genre?) -> Unit = {},
-    onUpdateSortType: (String) -> Unit = {}
+    onUpdateSortType: (String) -> Unit = {},
+    onViewAllRooms: () -> Unit = {}
 ) {
     val focusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
@@ -142,7 +144,8 @@ private fun GroupSearchContent(
                                     onUpdateSearchQuery(keyword)
                                     onSearchButtonClick()
                                 },
-                                onRemove = onDeleteRecentSearch
+                                onRemove = onDeleteRecentSearch,
+                                onViewAllRoomsClick = onViewAllRooms
                             )
                         }
                     }
@@ -164,7 +167,7 @@ private fun GroupSearchContent(
                         }
                     }
 
-                    uiState.isCompleteSearching -> {
+                    uiState.isCompleteSearching || uiState.isAllCategory -> {
                         GroupFilteredSearchResult(
                             genres = genreDisplayNames,
                             selectedGenreIndex = selectedGenreIndex,
@@ -173,15 +176,9 @@ private fun GroupSearchContent(
                                     uiState.genres.indexOf(uiState.selectedGenre)
                                 } else -1
 
-                                val selectedGenre = if (index == currentSelectedIndex) {
-                                    // 같은 장르를 다시 터치하면 선택 해제
-                                    null
-                                } else if (index >= 0 && index < uiState.genres.size) {
-                                    // 새로운 장르 선택
-                                    uiState.genres[index]
-                                } else {
-                                    null
-                                }
+                                val selectedGenre = if (index == currentSelectedIndex) null
+                                else if (index >= 0 && index < uiState.genres.size) uiState.genres[index]
+                                else null
                                 onUpdateSelectedGenre(selectedGenre)
                             },
                             resultCount = uiState.searchResults.size,
@@ -189,14 +186,15 @@ private fun GroupSearchContent(
                             onRoomClick = { room -> onRoomClick(room.roomId) },
                             canLoadMore = uiState.canLoadMore,
                             isLoadingMore = uiState.isLoadingMore,
-                            onLoadMore = onLoadMoreRooms
+                            onLoadMore = onLoadMoreRooms,
+                            isAllCategory = uiState.isAllCategory
                         )
                     }
                 }
             }
         }
 
-        if (uiState.isCompleteSearching) {
+        if (uiState.isCompleteSearching || uiState.isAllCategory) {
             FilterButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app/src/main/java/com/texthip/thip/ui/group/search/screen/GroupSearchScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/search/screen/GroupSearchScreen.kt
@@ -187,7 +187,6 @@ private fun GroupSearchContent(
                             canLoadMore = uiState.canLoadMore,
                             isLoadingMore = uiState.isLoadingMore,
                             onLoadMore = onLoadMoreRooms,
-                            isAllCategory = uiState.isAllCategory
                         )
                     }
                 }
@@ -198,7 +197,7 @@ private fun GroupSearchContent(
             FilterButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 196.dp, end = 20.dp),
+                    .padding(top = 174.dp, end = 20.dp),
                 selectedOption = sortOptions[selectedSortOptionIndex],
                 options = sortOptions,
                 onOptionSelected = { selected ->

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
@@ -71,8 +71,8 @@ fun NavHostController.navigateToRecommendedGroupRecruit(roomId: Int) {
 }
 
 // 진행중인 모임방 화면으로 이동
-fun NavHostController.navigateToGroupRoom(roomId: Int) {
-    navigate(GroupRoutes.Room(roomId))
+fun NavHostController.navigateToGroupRoom(roomId: Int, isExpired: Boolean = false) {
+    navigate(GroupRoutes.Room(roomId, isExpired))
 }
 
 // 독서메이트 화면으로 이동
@@ -81,17 +81,18 @@ fun NavHostController.navigateToGroupRoomMates(roomId: Int) {
 }
 
 // 오늘의 한마디 회면으로 이동
-fun NavHostController.navigateToGroupRoomChat(roomId: Int) {
-    navigate(GroupRoutes.RoomChat(roomId))
+fun NavHostController.navigateToGroupRoomChat(roomId: Int, isExpired: Boolean = false) {
+    navigate(GroupRoutes.RoomChat(roomId, isExpired))
 }
 
 // 기록장 화면으로 이동
 fun NavHostController.navigateToGroupNote(
     roomId: Int,
     page: Int? = null,
-    isOverview: Boolean? = null
+    isOverview: Boolean? = null,
+    isExpired: Boolean = false
 ) {
-    navigate(GroupRoutes.Note(roomId = roomId, page = page, isOverview = isOverview))
+    navigate(GroupRoutes.Note(roomId = roomId, page = page, isOverview = isOverview, isExpired = isExpired))
 }
 
 // 기록 생성 화면으로 이동

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
@@ -37,8 +37,8 @@ fun NavHostController.navigateToGroupDone() {
 }
 
 // 모임방 검색 화면으로 이동
-fun NavHostController.navigateToGroupSearch() {
-    navigate(GroupRoutes.Search)
+fun NavHostController.navigateToGroupSearch(viewAll: Boolean = false) {
+    navigate(GroupRoutes.Search(viewAll = viewAll))
 }
 
 // 내 모임방 화면으로 이동

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
@@ -144,6 +144,9 @@ fun NavGraphBuilder.groupNavigation(
     // Group Done 화면
     composable<GroupRoutes.Done> {
         GroupDoneScreen(
+            onRoomClick = { roomId ->
+                navController.navigateToGroupRoom(roomId, isExpired = true)
+            },
             onNavigateBack = {
                 navigateBack()
             }
@@ -161,7 +164,7 @@ fun NavGraphBuilder.groupNavigation(
                 if (isRecruiting) {
                     navController.navigateToGroupRecruit(room.roomId)
                 } else {
-                    navController.navigateToGroupRoom(room.roomId)
+                    navController.navigateToGroupRoom(room.roomId, isExpired = false)
                 }
             },
             onNavigateBack = {
@@ -256,9 +259,11 @@ fun NavGraphBuilder.groupNavigation(
     composable<GroupRoutes.Room> { backStackEntry ->
         val route = backStackEntry.toRoute<GroupRoutes.Room>()
         val roomId = route.roomId
+        val isExpired = route.isExpired
 
         GroupRoomScreen(
             roomId = roomId,
+            isExpired = isExpired,
             onBackClick = {
                 navigateBack()
             },
@@ -266,10 +271,10 @@ fun NavGraphBuilder.groupNavigation(
                 navController.navigateToGroupRoomMates(roomId)
             },
             onNavigateToChat = {
-                navController.navigateToGroupRoomChat(roomId)
+                navController.navigateToGroupRoomChat(roomId, isExpired)
             },
             onNavigateToNote = { page, isOverview ->
-                navController.navigateToGroupNote(roomId, page, isOverview)
+                navController.navigateToGroupNote(roomId, page, isOverview, isExpired)
             },
             onNavigateToBookDetail = { isbn ->
                 navController.navigateToBookDetail(isbn)
@@ -282,7 +287,8 @@ fun NavGraphBuilder.groupNavigation(
         val route = backStackEntry.toRoute<GroupRoutes.RoomMates>()
         val roomId = route.roomId
 
-        val feedViewModel: FeedViewModel = hiltViewModel(navController.getBackStackEntry(MainTabRoutes.Group))
+        val feedViewModel: FeedViewModel =
+            hiltViewModel(navController.getBackStackEntry(MainTabRoutes.Group))
         val feedUiState by feedViewModel.uiState.collectAsState()
         val myUserId = feedUiState.myFeedInfo?.creatorId
 
@@ -307,9 +313,12 @@ fun NavGraphBuilder.groupNavigation(
         )
     }
 
-    composable<GroupRoutes.RoomChat> {
+    composable<GroupRoutes.RoomChat> { backStackEntry ->
+        val route = backStackEntry.toRoute<GroupRoutes.RoomChat>()
+
         GroupRoomChatScreen(
             onBackClick = { navigateBack() },
+            isExpired = route.isExpired
         )
     }
 
@@ -319,12 +328,14 @@ fun NavGraphBuilder.groupNavigation(
         val roomId = route.roomId
         val page = route.page
         val isOverview = route.isOverview
+        val isExpired = route.isExpired
 
         val result = backStackEntry.savedStateHandle.get<Int>("selected_tab_index")
 
         val viewModel: GroupNoteViewModel = hiltViewModel(backStackEntry)
 
-        val feedViewModel: FeedViewModel = hiltViewModel(navController.getBackStackEntry(MainTabRoutes.Group))
+        val feedViewModel: FeedViewModel =
+            hiltViewModel(navController.getBackStackEntry(MainTabRoutes.Group))
         val feedUiState by feedViewModel.uiState.collectAsState()
         val myUserId = feedUiState.myFeedInfo?.creatorId
 
@@ -339,6 +350,7 @@ fun NavGraphBuilder.groupNavigation(
             resultTabIndex = result,
             initialPage = page,
             initialIsOverview = isOverview,
+            isExpired = isExpired,
             onResultConsumed = {
                 backStackEntry.savedStateHandle.remove<Int>("selected_tab_index")
             },

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
@@ -28,6 +28,7 @@ import com.texthip.thip.ui.group.room.screen.GroupRoomUnlockScreen
 import com.texthip.thip.ui.group.room.viewmodel.GroupRoomRecruitViewModel
 import com.texthip.thip.ui.group.screen.GroupScreen
 import com.texthip.thip.ui.group.search.screen.GroupSearchScreen
+import com.texthip.thip.ui.group.search.viewmodel.GroupSearchViewModel
 import com.texthip.thip.ui.group.viewmodel.GroupViewModel
 import com.texthip.thip.ui.navigator.extensions.navigateToAlarm
 import com.texthip.thip.ui.navigator.extensions.navigateToBookDetail
@@ -82,7 +83,7 @@ fun NavGraphBuilder.groupNavigation(
                 navController.navigateToAlarm()
             },
             onNavigateToGroupSearch = {
-                navController.navigateToGroupSearch()
+                navController.navigateToGroupSearch(viewAll = false)
             },
             onNavigateToGroupMy = {
                 navController.navigateToGroupMy()
@@ -92,6 +93,9 @@ fun NavGraphBuilder.groupNavigation(
             },
             onNavigateToGroupRoom = { roomId ->
                 navController.navigateToGroupRoom(roomId)
+            },
+            onNavigateToGroupSearchAllRooms = {
+                navController.navigateToGroupSearch(viewAll = true)
             }
         )
     }
@@ -174,14 +178,25 @@ fun NavGraphBuilder.groupNavigation(
     }
 
     // Group Search 화면
-    composable<GroupRoutes.Search> {
+    composable<GroupRoutes.Search> { backStackEntry ->
+        val route = backStackEntry.toRoute<GroupRoutes.Search>()
+        val viewModel: GroupSearchViewModel = hiltViewModel()
+
+        // [추가] 화면 진입 시 viewAll 플래그를 확인하고 ViewModel의 함수를 호출
+        LaunchedEffect(Unit) {
+            if (route.viewAll) {
+                viewModel.onViewAllRooms()
+            }
+        }
+
         GroupSearchScreen(
             onNavigateBack = {
                 navigateBack()
             },
             onRoomClick = { roomId ->
                 navController.navigateToGroupRecruit(roomId)
-            }
+            },
+            viewModel = viewModel
         )
     }
 

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
@@ -14,7 +14,7 @@ sealed class GroupRoutes : Routes() {
         val imageUrl: String,
         val author: String
     ) : GroupRoutes()
-    
+
     @Serializable
     data object Done : GroupRoutes()
 
@@ -31,17 +31,21 @@ sealed class GroupRoutes : Routes() {
     data class RoomUnlock(val roomId: Int) : GroupRoutes()
 
     @Serializable
-    data class Room(val roomId: Int) : GroupRoutes()
+    data class Room(val roomId: Int, val isExpired: Boolean = false) : GroupRoutes()
 
     @Serializable
     data class RoomMates(val roomId: Int) : GroupRoutes()
 
     @Serializable
-    data class RoomChat(val roomId: Int) : GroupRoutes()
+    data class RoomChat(val roomId: Int, val isExpired: Boolean = false) : GroupRoutes()
 
     @Serializable
-    data class Note(val roomId: Int, val page: Int? = null, val isOverview: Boolean? = null) :
-        GroupRoutes()
+    data class Note(
+        val roomId: Int,
+        val page: Int? = null,
+        val isOverview: Boolean? = null,
+        val isExpired: Boolean = false
+    ) : GroupRoutes()
 
     @Serializable
     data class NoteCreate(

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
@@ -19,7 +19,7 @@ sealed class GroupRoutes : Routes() {
     data object Done : GroupRoutes()
 
     @Serializable
-    data object Search : GroupRoutes()
+    data class Search(val viewAll: Boolean = false) : GroupRoutes()
 
     @Serializable
     data object My : GroupRoutes()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="percent">%</string>
     <string name="leave_room_toast">모임 나가기를 완료했어요.</string>
     <string name="leave_room_fail_toast">모임 나가기를 실패했어요.</string>
+    <string name="until_start">시작까지</string>
 
     <!--    group room    -->
     <string name="introduction_content">소개글</string>
@@ -256,6 +257,7 @@
     <string name="posting_complete">기록이 게시되었습니다!</string>
     <string name="delete_comment_title">이 댓글을 삭제하시겠어요?</string>
     <string name="comment_deleted">삭제된 댓글이에요.</string>
+    <string name="expired_room_read_only_message">완료된 모임방에서는 기존 기록에 대한 조회만 가능해요.</string>
 
     <!--    alarm    -->
     <string name="alarm_feed">피드</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="expired_room_read_only_message">완료된 모임방에서는 기존 기록에 대한 조회만 가능해요.</string>
     <string name="look_around_all_rooms">전체 모임방을 한 눈에 둘러보세요!</string>
     <string name="look_around_all_rooms_title">전체 모임방 둘러보기</string>
+    <string name="all">전체</string>
 
     <!--    alarm    -->
     <string name="alarm_feed">피드</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,7 +158,6 @@
     <string name="group_recommend">이런 모임방은 어때요?</string>
     <string name="group_recruiting">"모집"</string>
     <string name="group_genre">"장르"</string>
-    <string name="deadline_string">마감 임박한 독서 모임방</string>
     <string name="group_participant">%1$s명</string>
     <string name="group_participant_string">참여</string>
     <string name="group_progress">"%1$s님의 진행도 "</string>
@@ -414,7 +413,8 @@
     <string name="room_section_deadline">마감 임박한 독서 모임방</string>
     <string name="room_section_popular">인기 있는 독서 모임방</string>
     <string name="room_section_influencer">인플루언서·작가 독서 모임방</string>
-    
+    <string name="room_section_recent">최근 생성된 독서 모임방</string>
+
     <!--    error states    -->
     <string name="error_data_load_failed">데이터를 불러올 수 없습니다</string>
     <string name="error_network_connection">네트워크 연결을 확인해주세요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,8 @@
     <string name="delete_comment_title">이 댓글을 삭제하시겠어요?</string>
     <string name="comment_deleted">삭제된 댓글이에요.</string>
     <string name="expired_room_read_only_message">완료된 모임방에서는 기존 기록에 대한 조회만 가능해요.</string>
+    <string name="look_around_all_rooms">전체 모임방을 한 눈에 둘러보세요!</string>
+    <string name="look_around_all_rooms_title">전체 모임방 둘러보기</string>
 
     <!--    alarm    -->
     <string name="alarm_feed">피드</string>


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #138 

<br/>

## 🔎 작업 내용

- 내 모임방에서 아직 모집중인 모임방은 percent대신 deadline이 뜨도록 수정했습니다
- 완료된 모임방 구현 완료했습니다
- 완료된 모임방 -> kebab 없앰 (추후 방 나가기 구현되면 다시 보이게 하고 toast message 띄우게 수정)
- 기록장 -> 기록 좋아요, 수정, 삭제 등 불가하게 수정; 댓글 바텀시트에서 textfield 없앰; 댓글 및 답글 달기, 수정, 좋아요 등 불가하게 수정; 
- 오늘의 한마디 -> textfield 없앰; kebab 누르면 toast message 뜨게 수정
- 검색 화면에서 전체 모임방을 보여주는 플로우를 추가했습니다
- 최근 생성된 독서 모임방 캐러셀을 추가하고, 제일 첫번째에 보여지고, 캐러셀이 무한으로 돌아가도록 수정했습니다

 <br/>

## 📸 스크린샷  

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 😢 해결하지 못한 과제
- [] TASK

  <br/>

## 📢 리뷰어들에게
- 참고해야 할 사항들을 적어주세요

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 완료된(만료) 모임방 읽기 전용 모드 전면 적용: 입력/액션 비활성화 및 안내 토스트 노출.
  - 전체 모임방 보기 기능 추가 및 검색에서 "전체" 옵션 지원.
  - 최근 생성 섹션 추가로 최신 모임방 확인 가능.

- UI Changes
  - 내 방 카드: 마감일이 있으면 진행률 대신 “시작까지”+날짜 표시.
  - 그룹 화면에 전체 보기 버튼(전체 모임방 둘러보기) 및 관련 문구 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->