### PR TITLE
[FEAT] 알림 센터 API 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,16 @@
             android:name="com.kakao.sdk.AppKey"
             android:value="${NATIVE_APP_KEY}" />
 
+        <!-- FCM 기본 설정 -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@mipmap/ic_launcher" />
+            
+        <!-- FCM 기본 클릭 액션 설정 -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="thip_notifications" />
+
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
@@ -39,20 +49,21 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"
             android:label="@string/app_name"
             android:theme="@style/Theme.Thip">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
         <service
             android:name=".service.MyFirebaseMessagingService"
-            android:exported="false">
-            <intent-filter>
+            android:exported="false"
+            android:directBootAware="true">
+            <intent-filter android:priority="1000">
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>

--- a/app/src/main/java/com/texthip/thip/MainScreen.kt
+++ b/app/src/main/java/com/texthip/thip/MainScreen.kt
@@ -43,23 +43,20 @@ fun MainScreen(
     var feedReselectionTrigger by remember { mutableStateOf(0) }
     val context = LocalContext.current
     
-    // 처리된 알림 ID 추적 (중복 처리 방지)
+    // 처리된 알림 ID 추적
     var processedNotificationId by remember { mutableStateOf<String?>(null) }
 
     // 푸시 알림에서 온 경우 알림 읽기 API 호출 및 네비게이션
     LaunchedEffect(notificationData?.notificationId, notificationData?.fromNotification) {
         val data = notificationData
         
-        // 중복 처리 방지: 이미 처리한 알림이면 스킵
+        // 중복 처리 방지
         if (data?.notificationId == processedNotificationId) {
-            Log.d("MainScreen", "Notification already processed: ${data?.notificationId}")
             return@LaunchedEffect
         }
         
         data?.let { notificationData ->
             if (notificationData.fromNotification && notificationData.notificationId != null) {
-                Log.d("MainScreen", "Processing notification: ${notificationData.notificationId}")
-                
                 try {
                     val entryPoint = EntryPointAccessors.fromApplication(
                         context.applicationContext,
@@ -67,7 +64,6 @@ fun MainScreen(
                     )
                     val notificationRepository = entryPoint.notificationRepository()
 
-                    // 알림 ID를 Int로 변환 시도
                     val notificationId = try {
                         notificationData.notificationId.toInt()
                     } catch (e: NumberFormatException) {
@@ -79,11 +75,8 @@ fun MainScreen(
                     
                     result.onSuccess { response ->
                         if (response != null) {
-                            Log.d("MainScreen", "Notification check successful, navigating to: ${response.route}")
                             navController.navigateFromNotification(response)
-                            // 알림 상태 강제 새로고침 트리거
                             notificationRepository.onNotificationReceived()
-                            // 처리 완료 표시
                             processedNotificationId = notificationData.notificationId
                         } else {
                             Log.w("MainScreen", "Notification check returned null response")

--- a/app/src/main/java/com/texthip/thip/MainScreen.kt
+++ b/app/src/main/java/com/texthip/thip/MainScreen.kt
@@ -3,28 +3,101 @@ package com.texthip.thip
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.texthip.thip.data.repository.NotificationRepository
 import com.texthip.thip.ui.navigator.BottomNavigationBar
 import com.texthip.thip.ui.navigator.MainNavHost
 import com.texthip.thip.ui.navigator.extensions.isMainTabRoute
+import com.texthip.thip.ui.navigator.extensions.navigateFromNotification
 import com.texthip.thip.ui.navigator.routes.MainTabRoutes
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface MainScreenEntryPoint {
+    fun notificationRepository(): NotificationRepository
+}
 
 @Composable
 fun MainScreen(
-    onNavigateToLogin: () -> Unit
+    onNavigateToLogin: () -> Unit,
+    notificationData: MainActivity.NotificationData? = null
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     var feedReselectionTrigger by remember { mutableStateOf(0) }
+    val context = LocalContext.current
+    
+    // 처리된 알림 ID 추적 (중복 처리 방지)
+    var processedNotificationId by remember { mutableStateOf<String?>(null) }
+
+    // 푸시 알림에서 온 경우 알림 읽기 API 호출 및 네비게이션
+    LaunchedEffect(notificationData?.notificationId) {
+        val data = notificationData
+        
+        // 중복 처리 방지: 이미 처리한 알림이면 스킵
+        if (data?.notificationId == processedNotificationId) {
+            Log.d("MainScreen", "Notification already processed: ${data.notificationId}")
+            return@LaunchedEffect
+        }
+        
+        data?.let { notificationData ->
+            if (notificationData.fromNotification && notificationData.notificationId != null) {
+                Log.d("MainScreen", "Processing notification: ${notificationData.notificationId}")
+                
+                try {
+                    val entryPoint = EntryPointAccessors.fromApplication(
+                        context.applicationContext,
+                        MainScreenEntryPoint::class.java
+                    )
+                    val notificationRepository = entryPoint.notificationRepository()
+
+                    // 알림 ID를 Int로 변환 시도
+                    val notificationId = try {
+                        notificationData.notificationId.toInt()
+                    } catch (e: NumberFormatException) {
+                        Log.e("MainScreen", "Invalid notification ID format: ${notificationData.notificationId}", e)
+                        return@LaunchedEffect
+                    }
+
+                    val result = notificationRepository.checkNotification(notificationId)
+                    
+                    result.onSuccess { response ->
+                        if (response != null) {
+                            Log.d("MainScreen", "Notification check successful, navigating to: ${response.route}")
+                            navController.navigateFromNotification(response)
+                            // 알림 상태 강제 새로고침 트리거
+                            notificationRepository.onNotificationReceived()
+                            // 처리 완료 표시
+                            processedNotificationId = notificationData.notificationId
+                        } else {
+                            Log.w("MainScreen", "Notification check returned null response")
+                        }
+                    }.onFailure { exception ->
+                        Log.e("MainScreen", "Failed to check notification: ${notificationData.notificationId}", exception)
+                    }
+                    
+                } catch (e: Exception) {
+                    Log.e("MainScreen", "Unexpected error processing notification: ${notificationData.notificationId}", e)
+                }
+            }
+        }
+    }
 
     val showBottomBar = currentDestination?.isMainTabRoute() ?: true
 

--- a/app/src/main/java/com/texthip/thip/MainScreen.kt
+++ b/app/src/main/java/com/texthip/thip/MainScreen.kt
@@ -52,7 +52,7 @@ fun MainScreen(
         
         // 중복 처리 방지: 이미 처리한 알림이면 스킵
         if (data?.notificationId == processedNotificationId) {
-            Log.d("MainScreen", "Notification already processed: ${data.notificationId}")
+            Log.d("MainScreen", "Notification already processed: ${data?.notificationId}")
             return@LaunchedEffect
         }
         

--- a/app/src/main/java/com/texthip/thip/MainScreen.kt
+++ b/app/src/main/java/com/texthip/thip/MainScreen.kt
@@ -47,7 +47,7 @@ fun MainScreen(
     var processedNotificationId by remember { mutableStateOf<String?>(null) }
 
     // 푸시 알림에서 온 경우 알림 읽기 API 호출 및 네비게이션
-    LaunchedEffect(notificationData?.notificationId) {
+    LaunchedEffect(notificationData?.notificationId, notificationData?.fromNotification) {
         val data = notificationData
         
         // 중복 처리 방지: 이미 처리한 알림이면 스킵

--- a/app/src/main/java/com/texthip/thip/data/manager/FcmTokenManager.kt
+++ b/app/src/main/java/com/texthip/thip/data/manager/FcmTokenManager.kt
@@ -9,7 +9,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.firebase.messaging.FirebaseMessaging
 import com.texthip.thip.data.repository.NotificationRepository
 import com.texthip.thip.utils.auth.getAppScopeDeviceId
-import com.texthip.thip.utils.permission.NotificationPermissionUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -93,12 +92,6 @@ class FcmTokenManager @Inject constructor(
     }
 
     private suspend fun sendTokenToServer(token: String) {
-        // 알림 권한이 없으면 토큰을 서버에 전송하지 않음
-        if (!NotificationPermissionUtils.isNotificationPermissionGranted(context)) {
-            Log.w("FCM", "Notification permission not granted, skipping token registration")
-            return
-        }
-        
         val deviceId = context.getAppScopeDeviceId()
         notificationRepository.registerFcmToken(deviceId, token)
             .onSuccess {

--- a/app/src/main/java/com/texthip/thip/data/model/notification/request/NotificationCheckRequest.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/notification/request/NotificationCheckRequest.kt
@@ -1,0 +1,9 @@
+package com.texthip.thip.data.model.notification.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationCheckRequest(
+    @SerialName("notificationId") val notificationId: Int
+)

--- a/app/src/main/java/com/texthip/thip/data/model/notification/response/NotificationCheckResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/notification/response/NotificationCheckResponse.kt
@@ -1,0 +1,29 @@
+package com.texthip.thip.data.model.notification.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class NotificationCheckResponse(
+    @SerialName("route") val route: NotificationRoute,
+    @SerialName("params") val params: Map<String, JsonElement>
+)
+
+@Serializable
+enum class NotificationRoute {
+    @SerialName("FEED_USER")
+    FEED_USER,
+
+    @SerialName("FEED_DETAIL")
+    FEED_DETAIL,
+
+    @SerialName("ROOM_MAIN")
+    ROOM_MAIN,
+
+    @SerialName("ROOM_DETAIL")
+    ROOM_DETAIL,
+
+    @SerialName("ROOM_POST_DETAIL")
+    ROOM_POST_DETAIL
+}

--- a/app/src/main/java/com/texthip/thip/data/model/notification/response/NotificationListResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/notification/response/NotificationListResponse.kt
@@ -1,0 +1,21 @@
+package com.texthip.thip.data.model.notification.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationListResponse(
+    @SerialName("notifications") val notifications: List<NotificationResponse>,
+    @SerialName("nextCursor") val nextCursor: String?,
+    @SerialName("isLast") val isLast: Boolean
+)
+
+@Serializable
+data class NotificationResponse(
+    @SerialName("notificationId") val notificationId: Int,
+    @SerialName("title") val title: String,
+    @SerialName("content") val content: String,
+    @SerialName("isChecked") val isChecked: Boolean,
+    @SerialName("notificationType") val notificationType: String,
+    @SerialName("postDate") val postDate: String
+)

--- a/app/src/main/java/com/texthip/thip/data/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/NotificationRepository.kt
@@ -82,8 +82,8 @@ class NotificationRepository @Inject constructor(
     }
 
     suspend fun getNotifications(
-        type: String? = null,
-        cursor: String? = null
+        cursor: String? = null,
+        type: String? = null
     ): Result<NotificationListResponse?> {
         return runCatching {
             val response = notificationService.getNotifications(cursor, type)

--- a/app/src/main/java/com/texthip/thip/data/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/NotificationRepository.kt
@@ -6,6 +6,7 @@ import com.texthip.thip.data.model.notification.request.FcmTokenRequest
 import com.texthip.thip.data.model.notification.request.FcmTokenDeleteRequest
 import com.texthip.thip.data.model.notification.request.NotificationEnabledRequest
 import com.texthip.thip.data.model.notification.response.NotificationEnabledResponse
+import com.texthip.thip.data.model.notification.response.NotificationListResponse
 import com.texthip.thip.data.service.NotificationService
 import com.texthip.thip.utils.auth.getAppScopeDeviceId
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -57,6 +58,16 @@ class NotificationRepository @Inject constructor(
             val deviceId = context.getAppScopeDeviceId()
             val request = FcmTokenDeleteRequest(deviceId = deviceId)
             val response = notificationService.deleteFcmToken(request)
+            response.handleBaseResponse().getOrNull()
+        }
+    }
+    
+    suspend fun getNotifications(
+        type: String? = null,
+        cursor: String? = null
+    ): Result<NotificationListResponse?> {
+        return runCatching {
+            val response = notificationService.getNotifications(cursor, type)
             response.handleBaseResponse().getOrNull()
         }
     }

--- a/app/src/main/java/com/texthip/thip/data/service/NotificationService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/NotificationService.kt
@@ -4,6 +4,7 @@ import com.texthip.thip.data.model.notification.request.FcmTokenRequest
 import com.texthip.thip.data.model.notification.request.FcmTokenDeleteRequest
 import com.texthip.thip.data.model.notification.request.NotificationEnabledRequest
 import com.texthip.thip.data.model.notification.response.NotificationEnabledResponse
+import com.texthip.thip.data.model.notification.response.NotificationListResponse
 import com.texthip.thip.data.model.base.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -32,4 +33,10 @@ interface NotificationService {
     suspend fun deleteFcmToken(
         @Body request: FcmTokenDeleteRequest
     ): BaseResponse<Unit>
+    
+    @GET("notifications")
+    suspend fun getNotifications(
+        @Query("cursor") cursor: String? = null,
+        @Query("type") type: String? = null
+    ): BaseResponse<NotificationListResponse>
 }

--- a/app/src/main/java/com/texthip/thip/data/service/NotificationService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/NotificationService.kt
@@ -3,8 +3,10 @@ package com.texthip.thip.data.service
 import com.texthip.thip.data.model.notification.request.FcmTokenRequest
 import com.texthip.thip.data.model.notification.request.FcmTokenDeleteRequest
 import com.texthip.thip.data.model.notification.request.NotificationEnabledRequest
+import com.texthip.thip.data.model.notification.request.NotificationCheckRequest
 import com.texthip.thip.data.model.notification.response.NotificationEnabledResponse
 import com.texthip.thip.data.model.notification.response.NotificationListResponse
+import com.texthip.thip.data.model.notification.response.NotificationCheckResponse
 import com.texthip.thip.data.model.base.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -18,25 +20,30 @@ interface NotificationService {
     suspend fun registerFcmToken(
         @Body request: FcmTokenRequest
     ): BaseResponse<Unit>
-    
+
     @GET("users/notification-settings")
     suspend fun getNotificationEnableState(
         @Query("deviceId") deviceId: String
     ): BaseResponse<NotificationEnabledResponse>
-    
+
     @PATCH("notifications/enable-state")
     suspend fun updateNotificationEnabled(
         @Body request: NotificationEnabledRequest
     ): BaseResponse<NotificationEnabledResponse>
-    
+
     @DELETE("notifications/fcm-tokens")
     suspend fun deleteFcmToken(
         @Body request: FcmTokenDeleteRequest
     ): BaseResponse<Unit>
-    
+
     @GET("notifications")
     suspend fun getNotifications(
         @Query("cursor") cursor: String? = null,
         @Query("type") type: String? = null
     ): BaseResponse<NotificationListResponse>
+
+    @POST("notifications/check")
+    suspend fun checkNotification(
+        @Body request: NotificationCheckRequest
+    ): BaseResponse<NotificationCheckResponse>
 }

--- a/app/src/main/java/com/texthip/thip/service/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/texthip/thip/service/MyFirebaseMessagingService.kt
@@ -37,13 +37,11 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         super.onMessageReceived(remoteMessage)
 
 
-        // 푸시 알림 도착 시 알림 상태 새로고침
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                notificationRepository.onNotificationReceived()
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to trigger notification refresh", e)
-            }
+        // 푸시 알림 도착 시 알림 상태 새로고침 (비차단 방식)
+        try {
+            notificationRepository.onNotificationReceived()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to trigger notification refresh", e)
         }
 
         // Data payload 처리

--- a/app/src/main/java/com/texthip/thip/service/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/texthip/thip/service/MyFirebaseMessagingService.kt
@@ -11,6 +11,7 @@ import com.google.firebase.messaging.RemoteMessage
 import com.texthip.thip.MainActivity
 import com.texthip.thip.R
 import com.texthip.thip.data.manager.FcmTokenManager
+import com.texthip.thip.data.repository.NotificationRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +23,9 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     @Inject
     lateinit var fcmTokenManager: FcmTokenManager
 
+    @Inject
+    lateinit var notificationRepository: NotificationRepository
+
     companion object {
         private const val TAG = "FCM"
         private const val CHANNEL_ID = "thip_notifications"
@@ -32,16 +36,27 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)
 
-        Log.d(TAG, "From: ${remoteMessage.from}")
 
-        if (remoteMessage.data.isNotEmpty()) {
-            Log.d(TAG, "Message data payload: ${remoteMessage.data}")
+        // 푸시 알림 도착 시 알림 상태 새로고침
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                notificationRepository.onNotificationReceived()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to trigger notification refresh", e)
+            }
         }
 
-        remoteMessage.notification?.let {
-            Log.d(TAG, "Message Notification Body: ${it.body}")
-            showNotification(it.title, it.body)
+        // Data payload 처리
+        val dataPayload = remoteMessage.data
+        if (dataPayload.isNotEmpty()) {
+            Log.d(TAG, "Message data payload: $dataPayload")
         }
+
+        val title = remoteMessage.notification?.title ?: "THIP"
+        val body = remoteMessage.notification?.body ?: "새로운 알림이 있습니다"
+
+        Log.d(TAG, "App is in foreground, showing custom notification: title=$title, body=$body")
+        showNotification(title, body, dataPayload)
     }
 
     override fun onNewToken(token: String) {
@@ -54,39 +69,56 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun showNotification(title: String?, messageBody: String?) {
+    private fun showNotification(
+        title: String?,
+        messageBody: String?,
+        dataPayload: Map<String, String>
+    ) {
         val intent = Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            // FCM 데이터를 Intent에 추가
+            dataPayload["notificationId"]?.let { notificationId ->
+                putExtra("notification_id", notificationId)
+                putExtra("from_notification", true)
+            }
         }
 
         val pendingIntent = PendingIntent.getActivity(
             this,
-            0,
+            System.currentTimeMillis().toInt(), // 고유한 requestCode 사용
             intent,
-            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
         createNotificationChannel()
 
         val notificationBuilder = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title ?: "THIP")
             .setContentText(messageBody)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(0, notificationBuilder.build())
+        val notificationId =
+            dataPayload["notificationId"]?.toIntOrNull() ?: System.currentTimeMillis().toInt()
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
     private fun createNotificationChannel() {
         val channel = NotificationChannel(
             CHANNEL_ID,
             CHANNEL_NAME,
-            NotificationManager.IMPORTANCE_DEFAULT
+            NotificationManager.IMPORTANCE_HIGH
         ).apply {
             description = CHANNEL_DESCRIPTION
+            enableVibration(true)
+            setShowBadge(true)
+            enableLights(true)
         }
 
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/component/AlarmFilterRow.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/component/AlarmFilterRow.kt
@@ -24,11 +24,13 @@ fun AlarmFilterRow(
         OptionChipButton(
             text = stringResource(R.string.alarm_feed),
             isFilled = true,
+            isSelected = selectedStates[0],
             onClick = { onToggle(0) }
         )
         OptionChipButton(
             text = stringResource(R.string.alarm_group),
             isFilled = true,
+            isSelected = selectedStates[1],
             onClick = { onToggle(1) }
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/mock/NotificationType.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/mock/NotificationType.kt
@@ -1,0 +1,7 @@
+package com.texthip.thip.ui.common.alarmpage.mock
+
+enum class NotificationType(val value: String) {
+    FEED_AND_ROOM("feedAndRoom"),
+    FEED("feed"),
+    ROOM("room")
+}

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/screen/AlarmScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/screen/AlarmScreen.kt
@@ -9,39 +9,88 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.texthip.thip.R
+import com.texthip.thip.data.model.notification.response.NotificationResponse
 import com.texthip.thip.ui.common.alarmpage.component.AlarmFilterRow
-import com.texthip.thip.ui.common.alarmpage.mock.AlarmItem
 import com.texthip.thip.ui.common.alarmpage.component.CardAlarm
+import com.texthip.thip.ui.common.alarmpage.mock.NotificationType
+import com.texthip.thip.ui.common.alarmpage.viewmodel.AlarmUiState
+import com.texthip.thip.ui.common.alarmpage.viewmodel.AlarmViewModel
 import com.texthip.thip.ui.common.topappbar.DefaultTopAppBar
 import com.texthip.thip.ui.theme.ThipTheme
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AlarmScreen(
-    alarmItems: List<AlarmItem>, 
-    onCardClick: (AlarmItem) -> Unit = {},  // 나중에 서버랑 연동할 때 사용
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
+    viewModel: AlarmViewModel = hiltViewModel()
 ) {
-    var selectedStates by remember { mutableStateOf(booleanArrayOf(false, false)) }
-    var alarms by remember { mutableStateOf(alarmItems) }
+    val uiState by viewModel.uiState.collectAsState()
 
-    val filteredList = when {
-        selectedStates[0] && !selectedStates[1] -> alarms.filter { it.badgeText == stringResource(R.string.alarm_feed) }
-        !selectedStates[0] && selectedStates[1] -> alarms.filter { it.badgeText == stringResource(R.string.alarm_group) }
-        else -> alarms
+    LaunchedEffect(key1 = Unit) {
+        viewModel.refreshData()
+    }
+
+    AlarmContent(
+        uiState = uiState,
+        onNavigateBack = onNavigateBack,
+        onRefresh = { viewModel.refreshData() },
+        onLoadMore = { viewModel.loadMoreNotifications() },
+        onChangeNotificationType = { viewModel.changeNotificationType(it) }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlarmContent(
+    uiState: AlarmUiState,
+    onNavigateBack: () -> Unit = {},
+    onRefresh: () -> Unit = {},
+    onLoadMore: () -> Unit = {},
+    onChangeNotificationType: (NotificationType) -> Unit = {}
+) {
+    val listState = rememberLazyListState()
+
+    // 무한 스크롤 로직
+    val shouldLoadMore by remember(uiState.canLoadMore, uiState.isLoadingMore) {
+        derivedStateOf {
+            val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val totalItems = listState.layoutInfo.totalItemsCount
+            uiState.canLoadMore && !uiState.isLoadingMore && totalItems > 0 && lastVisibleIndex >= totalItems - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) {
+            onLoadMore()
+        }
+    }
+
+    // 필터 상태 매핑
+    val selectedStates = remember(uiState.currentNotificationType) {
+        when (uiState.currentNotificationType) {
+            NotificationType.FEED -> booleanArrayOf(true, false)
+            NotificationType.ROOM -> booleanArrayOf(false, true)
+            else -> booleanArrayOf(false, false) // FEED_AND_ROOM
+        }
     }
 
     Column(
@@ -52,49 +101,79 @@ fun AlarmScreen(
             title = stringResource(R.string.alarm_string),
             onLeftClick = onNavigateBack,
         )
-        Column(
-            Modifier
-                .fillMaxSize()
-                .padding(horizontal = 20.dp)
+
+        PullToRefreshBox(
+            isRefreshing = uiState.isLoading,
+            onRefresh = onRefresh,
+            modifier = Modifier.fillMaxSize()
         ) {
-            Spacer(modifier = Modifier.height(20.dp))
-            AlarmFilterRow(
-                selectedStates = selectedStates, onToggle = { idx ->
-                    selectedStates = selectedStates.copyOf().also { it[idx] = !it[idx] }
-                })
-            Spacer(modifier = Modifier.height(20.dp))
-
-            if (filteredList.isEmpty()) {
-
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = stringResource(R.string.alarm_notification_comment),
-                        style = typography.smalltitle_sb600_s18_h24,
-                        color = colors.White
-                    )
-                }
-            } else {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(20.dp),
-                    contentPadding = PaddingValues(bottom = 20.dp),
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    items(filteredList, key = { it.id }) { alarm ->
-                        CardAlarm(
-                            badgeText = alarm.badgeText,
-                            title = alarm.title,
-                            message = alarm.message,
-                            timeAgo = alarm.timeAgo,
-                            isRead = alarm.isRead,
-                            onClick = {
-                                alarms = alarms.map {
-                                    if (it.id == alarm.id) it.copy(isRead = true) else it
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp)
+            ) {
+                Spacer(modifier = Modifier.height(20.dp))
+                AlarmFilterRow(
+                    selectedStates = selectedStates,
+                    onToggle = { idx ->
+                        val newNotificationType = when {
+                            // 피드 버튼을 눌렀을 때
+                            idx == 0 -> {
+                                if (selectedStates[0]) {
+                                    // 이미 선택된 상태면 전체로 변경
+                                    NotificationType.FEED_AND_ROOM
+                                } else {
+                                    // 선택되지 않은 상태면 피드만
+                                    NotificationType.FEED
                                 }
-                            })
+                            }
+                            // 모임 버튼을 눌렀을 때  
+                            idx == 1 -> {
+                                if (selectedStates[1]) {
+                                    NotificationType.FEED_AND_ROOM
+                                } else {
+                                    NotificationType.ROOM
+                                }
+                            }
+
+                            else -> NotificationType.FEED_AND_ROOM
+                        }
+                        onChangeNotificationType(newNotificationType)
+                    }
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+
+                if (uiState.notifications.isNotEmpty()) {
+                    LazyColumn(
+                        state = listState,
+                        verticalArrangement = Arrangement.spacedBy(20.dp),
+                        contentPadding = PaddingValues(bottom = 20.dp),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(uiState.notifications, key = { it.notificationId }) { notification ->
+                            CardAlarm(
+                                badgeText = notification.notificationType,
+                                title = removeBracketPrefix(notification.title),
+                                message = notification.content,
+                                timeAgo = notification.postDate,
+                                isRead = notification.isChecked,
+                                onClick = {
+                                    // TODO: 알림 읽음 처리
+                                }
+                            )
+                        }
+                    }
+                } else if (!uiState.isLoading) {
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = stringResource(R.string.alarm_notification_comment),
+                            style = typography.smalltitle_sb600_s18_h24,
+                            color = colors.White
+                        )
                     }
                 }
             }
@@ -102,17 +181,46 @@ fun AlarmScreen(
     }
 }
 
+private fun removeBracketPrefix(title: String): String {
+    return title.replace(Regex("^\\[.*?\\]\\s*"), "").trim()
+}
+
 
 @Preview(showBackground = true)
 @Composable
 fun AlarmScreenPreview() {
     ThipTheme {
-        AlarmScreen(
-            alarmItems = listOf(
-                AlarmItem(1, "피드", "내 글을 좋아합니다.", "user123님이 내 글에 좋아요를 눌렀어요.", "2", false),
-                AlarmItem(2, "모임", "같이 읽기를 시작했어요!", "모임방에서 20분 동안 같이 읽기가 시작되었어요!", "7", false),
-                AlarmItem(3, "피드", "내 글에 댓글이 달렸어요.", "user1: 진짜 공감합니다!", "2025.01.12", true),
-                AlarmItem(4, "모임", "투표가 시작되었어요!", "투표지를 먼저 열람합니다.", "17", false)
+        AlarmContent(
+            uiState = AlarmUiState(
+                notifications = listOf(
+                    NotificationResponse(
+                        notificationId = 1,
+                        title = "[피드] 내 글을 좋아합니다.",
+                        content = "user123님이 내 글에 좋아요를 눌렀어요.",
+                        isChecked = false,
+                        notificationType = "피드",
+                        postDate = "2시간 전"
+                    ),
+                    NotificationResponse(
+                        notificationId = 2,
+                        title = "[모임] 같이 읽기를 시작했어요!",
+                        content = "모임방에서 20분 동안 같이 읽기가 시작되었어요!",
+                        isChecked = false,
+                        notificationType = "모임",
+                        postDate = "7시간 전"
+                    ),
+                    NotificationResponse(
+                        notificationId = 3,
+                        title = "[모임] 투표가 시작되었어요!",
+                        content = "투표지를 먼저 열람합니다.",
+                        isChecked = true,
+                        notificationType = "모임",
+                        postDate = "17시간 전"
+                    )
+                ),
+                currentNotificationType = NotificationType.FEED_AND_ROOM,
+                isLoading = false,
+                hasMore = true
             )
         )
     }
@@ -122,8 +230,11 @@ fun AlarmScreenPreview() {
 @Composable
 fun AlarmScreenEmptyPreview() {
     ThipTheme {
-        AlarmScreen(
-            alarmItems = emptyList()
+        AlarmContent(
+            uiState = AlarmUiState(
+                notifications = emptyList(),
+                isLoading = false
+            )
         )
     }
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/screen/AlarmScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/screen/AlarmScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.texthip.thip.R
+import com.texthip.thip.data.model.notification.response.NotificationCheckResponse
 import com.texthip.thip.data.model.notification.response.NotificationResponse
 import com.texthip.thip.ui.common.alarmpage.component.AlarmFilterRow
 import com.texthip.thip.ui.common.alarmpage.component.CardAlarm
@@ -41,6 +42,7 @@ import com.texthip.thip.ui.theme.ThipTheme.typography
 @Composable
 fun AlarmScreen(
     onNavigateBack: () -> Unit = {},
+    onNotificationNavigation: (NotificationCheckResponse) -> Unit = {},
     viewModel: AlarmViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -54,7 +56,12 @@ fun AlarmScreen(
         onNavigateBack = onNavigateBack,
         onRefresh = { viewModel.refreshData() },
         onLoadMore = { viewModel.loadMoreNotifications() },
-        onChangeNotificationType = { viewModel.changeNotificationType(it) }
+        onChangeNotificationType = { viewModel.changeNotificationType(it) },
+        onNotificationClick = { notificationId ->
+            viewModel.checkNotification(notificationId) { response ->
+                onNotificationNavigation(response)
+            }
+        }
     )
 }
 
@@ -65,7 +72,8 @@ fun AlarmContent(
     onNavigateBack: () -> Unit = {},
     onRefresh: () -> Unit = {},
     onLoadMore: () -> Unit = {},
-    onChangeNotificationType: (NotificationType) -> Unit = {}
+    onChangeNotificationType: (NotificationType) -> Unit = {},
+    onNotificationClick: (Int) -> Unit = {}
 ) {
     val listState = rememberLazyListState()
 
@@ -158,7 +166,7 @@ fun AlarmContent(
                                 timeAgo = notification.postDate,
                                 isRead = notification.isChecked,
                                 onClick = {
-                                    // TODO: 알림 읽음 처리
+                                    onNotificationClick(notification.notificationId)
                                 }
                             )
                         }

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmUiState.kt
@@ -1,0 +1,15 @@
+package com.texthip.thip.ui.common.alarmpage.viewmodel
+
+import com.texthip.thip.data.model.notification.response.NotificationResponse
+import com.texthip.thip.ui.common.alarmpage.mock.NotificationType
+
+data class AlarmUiState(
+    val notifications: List<NotificationResponse> = emptyList(),
+    val currentNotificationType: NotificationType = NotificationType.FEED_AND_ROOM,
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val hasMore: Boolean = true,
+    val error: String? = null
+) {
+    val canLoadMore: Boolean get() = !isLoading && !isLoadingMore && hasMore
+}

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmUiState.kt
@@ -12,4 +12,5 @@ data class AlarmUiState(
     val error: String? = null
 ) {
     val canLoadMore: Boolean get() = !isLoading && !isLoadingMore && hasMore
+    val hasUnreadNotifications: Boolean get() = notifications.any { !it.isChecked }
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmViewModel.kt
@@ -78,7 +78,7 @@ class AlarmViewModel @Inject constructor(
         }
 
         // 하나의 loadJob에 작업 바인딩
-        loadJob = viewModelScope.launch {
+        val currentJob = viewModelScope.launch {
             try {
                 val type =
                     if (uiState.value.currentNotificationType == NotificationType.FEED_AND_ROOM) {
@@ -110,14 +110,14 @@ class AlarmViewModel @Inject constructor(
                         updateState { it.copy(error = exception.message) }
                     }
             } finally {
-                isLoadingData = false
-                updateState { it.copy(isLoading = false, isLoadingMore = false) }
-                // 작업 완료 시 job 참조 정리
-                if (loadJob?.isCompleted == true) {
+                if (loadJob == coroutineContext[Job]) {
+                    isLoadingData = false
+                    updateState { it.copy(isLoading = false, isLoadingMore = false) }
                     loadJob = null
                 }
             }
         }
+        loadJob = currentJob
     }
 
     fun loadMoreNotifications() {

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmViewModel.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmViewModel.kt
@@ -87,7 +87,7 @@ class AlarmViewModel @Inject constructor(
                         uiState.value.currentNotificationType.value
                     }
 
-                repository.getNotifications(type, nextCursor)
+                repository.getNotifications(nextCursor, type)
                     .onSuccess { notificationListResponse ->
                         notificationListResponse?.let { response ->
                             val currentList =

--- a/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
@@ -43,10 +43,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.texthip.thip.R
 import com.texthip.thip.data.model.feed.response.AllFeedItem
 import com.texthip.thip.data.model.users.response.RecentWriterList
+import com.texthip.thip.ui.common.alarmpage.viewmodel.AlarmViewModel
 import com.texthip.thip.ui.common.buttons.FloatingButton
 import com.texthip.thip.ui.common.header.AuthorHeader
 import com.texthip.thip.ui.common.header.HeaderMenuBarTab
@@ -66,7 +66,6 @@ import com.texthip.thip.utils.color.hexToColor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FeedScreen(
@@ -85,8 +84,10 @@ fun FeedScreen(
     onRefreshConsumed: () -> Unit = {},
     navController: NavHostController,
     feedViewModel: FeedViewModel = hiltViewModel(),
+    alarmViewModel: AlarmViewModel = hiltViewModel()
 ) {
     val feedUiState by feedViewModel.uiState.collectAsState()
+    val alarmUiState by alarmViewModel.uiState.collectAsState()
     val scope = rememberCoroutineScope()
     var showProgressBar by remember { mutableStateOf(false) }
     val progress = remember { Animatable(0f) }
@@ -256,6 +257,7 @@ fun FeedScreen(
 
     FeedContent(
         feedUiState = feedUiState,
+        hasUnreadNotifications = alarmUiState.notifications.any { !it.isChecked },
         showProgressBar = showProgressBar,
         progress = progress.value,
         currentListState = currentListState,
@@ -289,7 +291,8 @@ fun FeedScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FeedContent(
-    feedUiState: com.texthip.thip.ui.feed.viewmodel.FeedUiState,
+    feedUiState: FeedUiState,
+    hasUnreadNotifications: Boolean,
     showProgressBar: Boolean,
     progress: Float,
     currentListState: LazyListState,
@@ -331,7 +334,7 @@ private fun FeedContent(
             ) {
                 LogoTopAppBar(
                     leftIcon = painterResource(R.drawable.ic_plusfriend),
-                    hasNotification = false,
+                    hasNotification = hasUnreadNotifications,
                     onLeftClick = onNavigateToSearchPeople,
                     onRightClick = onNavigateToNotification,
                 )
@@ -659,6 +662,7 @@ private fun FeedContentPreview() {
                     )
                 )
             ),
+            hasUnreadNotifications = false,
             showProgressBar = false,
             progress = 0f,
             currentListState = LazyListState(),

--- a/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
@@ -224,6 +224,7 @@ fun FeedScreen(
     LaunchedEffect(onFeedTabReselected) {
         if (onFeedTabReselected > 0) {
             feedViewModel.refreshOnBottomNavReselect()
+            alarmViewModel.refreshData()
             currentListState.scrollToItem(0)
         }
     }
@@ -285,7 +286,10 @@ fun FeedScreen(
         },
         onChangeFeedLike = feedViewModel::changeFeedLike,
         onChangeFeedSave = feedViewModel::changeFeedSave,
-        onPullToRefresh = feedViewModel::pullToRefresh
+        onPullToRefresh = {
+            feedViewModel.pullToRefresh()
+            alarmViewModel.refreshData()
+        }
     )
 }
 

--- a/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
@@ -155,7 +155,8 @@ fun FeedScreen(
         val hasUpdatedFeedData =
             navController.currentBackStackEntry?.savedStateHandle?.get<Long>("updated_feed_id") != null
         val fromProfile =
-            navController.currentBackStackEntry?.savedStateHandle?.get<Boolean>("from_profile") ?: false
+            navController.currentBackStackEntry?.savedStateHandle?.get<Boolean>("from_profile")
+                ?: false
 
         if (!hasUpdatedFeedData && !fromProfile) {
             // 일반적인 경우: 전체 새로고침 + 스크롤 상단 이동
@@ -178,7 +179,7 @@ fun FeedScreen(
             isUserTabChange = false
         }
     }
-    
+
     // 같은 탭 재클릭 시 스크롤 상단 이동 처리
     LaunchedEffect(shouldScrollToTop) {
         if (shouldScrollToTop) {
@@ -186,7 +187,7 @@ fun FeedScreen(
             shouldScrollToTop = false
         }
     }
-    
+
     // 중복된 로직 제거 - 기존 bottomNavReselected 방식만 사용
 
     LaunchedEffect(resultFeedId) {
@@ -218,7 +219,7 @@ fun FeedScreen(
             }
         }
     }
-    
+
     // 바텀 네비게이션 탭 재선택 처리 (직접 상태 전달 방식)
     LaunchedEffect(onFeedTabReselected) {
         if (onFeedTabReselected > 0) {
@@ -257,7 +258,7 @@ fun FeedScreen(
 
     FeedContent(
         feedUiState = feedUiState,
-        hasUnreadNotifications = alarmUiState.notifications.any { !it.isChecked },
+        hasUnreadNotifications = alarmUiState.hasUnreadNotifications,
         showProgressBar = showProgressBar,
         progress = progress.value,
         currentListState = currentListState,

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -70,7 +70,7 @@ fun GroupScreen(
 
     GroupContent(
         uiState = uiState,
-        hasUnreadNotifications = alarmUiState.notifications.any { !it.isChecked },
+        hasUnreadNotifications = alarmUiState.hasUnreadNotifications,
         onNavigateToMakeRoom = onNavigateToMakeRoom,
         onNavigateToGroupDone = onNavigateToGroupDone,
         onNavigateToAlarm = onNavigateToAlarm,
@@ -141,7 +141,13 @@ fun GroupContent(
                     groupCards = uiState.myJoinedRooms,
                     userName = uiState.userName,
                     onCardClick = { joinedRoom ->
-                        onNavigateToGroupRoom(joinedRoom.roomId)
+                        if (joinedRoom.deadlineDate == null) {
+                            // 시작 후
+                            onNavigateToGroupRoom(joinedRoom.roomId)
+                        } else {
+                            // 시작 전
+                            onNavigateToGroupRecruit(joinedRoom.roomId)
+                        }
                     },
                     onCardVisible = onCardVisible
                 )

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -33,6 +33,7 @@ import com.texthip.thip.data.model.rooms.response.RoomMainList
 import com.texthip.thip.data.model.rooms.response.RoomMainResponse
 import com.texthip.thip.ui.common.buttons.FloatingButton
 import com.texthip.thip.ui.common.modal.ToastWithDate
+import com.texthip.thip.ui.common.alarmpage.viewmodel.AlarmViewModel
 import com.texthip.thip.ui.common.topappbar.LogoTopAppBar
 import com.texthip.thip.ui.group.myroom.component.GroupMySectionHeader
 import com.texthip.thip.ui.group.myroom.component.GroupPager
@@ -54,16 +55,19 @@ fun GroupScreen(
     onNavigateToGroupMy: () -> Unit = {},   // 내 모임방 화면으로 이동
     onNavigateToGroupRecruit: (Int) -> Unit = {},   // 모집 중인 모임방 화면으로 이동
     onNavigateToGroupRoom: (Int) -> Unit = {},  // 기록장 화면으로 이동
-    viewModel: GroupViewModel = hiltViewModel()
+    viewModel: GroupViewModel = hiltViewModel(),
+    alarmViewModel: AlarmViewModel = hiltViewModel()
 ) {
     // 화면 재진입 시 데이터 새로고침
     LaunchedEffect(Unit) {
         viewModel.resetToInitialState()
     }
     val uiState by viewModel.uiState.collectAsState()
+    val alarmUiState by alarmViewModel.uiState.collectAsState()
 
     GroupContent(
         uiState = uiState,
+        hasUnreadNotifications = alarmUiState.notifications.any { !it.isChecked },
         onNavigateToMakeRoom = onNavigateToMakeRoom,
         onNavigateToGroupDone = onNavigateToGroupDone,
         onNavigateToAlarm = onNavigateToAlarm,
@@ -82,6 +86,7 @@ fun GroupScreen(
 @Composable
 fun GroupContent(
     uiState: GroupUiState,
+    hasUnreadNotifications: Boolean = false,
     onNavigateToMakeRoom: () -> Unit = {},
     onNavigateToGroupDone: () -> Unit = {},
     onNavigateToAlarm: () -> Unit = {},
@@ -162,7 +167,7 @@ fun GroupContent(
         // 상단바
         LogoTopAppBar(
             leftIcon = painterResource(R.drawable.ic_done),
-            hasNotification = false,
+            hasNotification = hasUnreadNotifications,
             onLeftClick = onNavigateToGroupDone,
             onRightClick = onNavigateToAlarm
         )

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -64,6 +64,7 @@ fun GroupScreen(
     // 화면 재진입 시 데이터 새로고침
     LaunchedEffect(Unit) {
         viewModel.resetToInitialState()
+        alarmViewModel.refreshData()
     }
     val uiState by viewModel.uiState.collectAsState()
     val alarmUiState by alarmViewModel.uiState.collectAsState()
@@ -79,7 +80,10 @@ fun GroupScreen(
         onNavigateToGroupRecruit = onNavigateToGroupRecruit,
         onNavigateToGroupRoom = onNavigateToGroupRoom,
         onNavigateToGroupSearchAllRooms = onNavigateToGroupSearchAllRooms,
-        onRefreshGroupData = { viewModel.refreshGroupData() },
+        onRefreshGroupData = { 
+            viewModel.refreshGroupData()
+            alarmViewModel.refreshData()
+        },
         onCardVisible = { cardIndex -> viewModel.loadMoreGroups() },
         onSelectGenre = { genreIndex -> viewModel.selectGenre(genreIndex) },
         onHideToast = { viewModel.hideToast() },

--- a/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageNotificationEditScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageNotificationEditScreen.kt
@@ -1,5 +1,7 @@
 package com.texthip.thip.ui.mypage.screen
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
@@ -21,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +39,7 @@ import com.texthip.thip.ui.mypage.viewmodel.MypageNotificationEditUiState
 import com.texthip.thip.ui.mypage.viewmodel.MypageNotificationEditViewModel
 import com.texthip.thip.ui.theme.ThipTheme.colors
 import com.texthip.thip.ui.theme.ThipTheme.typography
+import com.texthip.thip.utils.permission.NotificationPermissionUtils
 import kotlinx.coroutines.delay
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -46,9 +50,29 @@ fun MyPageNotificationEditScreen(
     onNavigateBack: () -> Unit,
     viewModel: MypageNotificationEditViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var toastMessage by rememberSaveable { mutableStateOf<String?>(null) }
     var toastDateTime by rememberSaveable { mutableStateOf("") }
+
+    // 알림 권한 요청 런처
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { isGranted ->
+            if (isGranted) {
+                // 권한이 허용되면 알림 활성화
+                viewModel.onNotificationToggle(true)
+                toastMessage = "push_on"
+                val dateFormat = SimpleDateFormat("yyyy년 M월 d일 H시 m분", Locale.KOREAN)
+                toastDateTime = dateFormat.format(Date())
+            } else {
+                // 권한이 거부되면 토스트 메시지 표시
+                toastMessage = "permission_denied"
+                val dateFormat = SimpleDateFormat("yyyy년 M월 d일 H시 m분", Locale.KOREAN)
+                toastDateTime = dateFormat.format(Date())
+            }
+        }
+    )
 
     LaunchedEffect(toastMessage) {
         if (toastMessage != null) {
@@ -63,10 +87,25 @@ fun MyPageNotificationEditScreen(
         toastDateTime = toastDateTime,
         onNavigateBack = onNavigateBack,
         onNotificationToggle = { enabled ->
-            viewModel.onNotificationToggle(enabled)
-            toastMessage = if (enabled) "push_on" else "push_off"
-            val dateFormat = SimpleDateFormat("yyyy년 M월 d일 H시 m분", Locale.KOREAN)
-            toastDateTime = dateFormat.format(Date())
+            if (enabled) {
+                // 알림을 켜려고 할 때 권한 확인
+                if (NotificationPermissionUtils.shouldRequestNotificationPermission(context)) {
+                    // 권한이 필요하면 권한 요청
+                    notificationPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+                } else {
+                    // 권한이 이미 있거나 필요없으면 바로 설정 변경
+                    viewModel.onNotificationToggle(enabled)
+                    toastMessage = "push_on"
+                    val dateFormat = SimpleDateFormat("yyyy년 M월 d일 H시 m분", Locale.KOREAN)
+                    toastDateTime = dateFormat.format(Date())
+                }
+            } else {
+                // 알림을 끄는 경우는 권한 체크 없이 바로 설정 변경
+                viewModel.onNotificationToggle(enabled)
+                toastMessage = "push_off"
+                val dateFormat = SimpleDateFormat("yyyy년 M월 d일 H시 m분", Locale.KOREAN)
+                toastDateTime = dateFormat.format(Date())
+            }
         }
     )
 }
@@ -97,9 +136,12 @@ fun MyPageNotificationEditContent(
         ) {
             toastMessage?.let { message ->
                 ToastWithDate(
-                    message = stringResource(
-                        if (message == "push_on") R.string.push_on else R.string.push_off
-                    ),
+                    message = when (message) {
+                        "push_on" -> stringResource(R.string.push_on)
+                        "push_off" -> stringResource(R.string.push_off)
+                        "permission_denied" -> "알림 권한이 필요합니다. 설정에서 권한을 허용해주세요."
+                        else -> stringResource(R.string.push_off)
+                    },
                     date = toastDateTime,
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageNotificationEditScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/mypage/screen/MypageNotificationEditScreen.kt
@@ -139,7 +139,7 @@ fun MyPageNotificationEditContent(
                     message = when (message) {
                         "push_on" -> stringResource(R.string.push_on)
                         "push_off" -> stringResource(R.string.push_off)
-                        "permission_denied" -> "알림 권한이 필요합니다. 설정에서 권한을 허용해주세요."
+                        "permission_denied" -> stringResource(R.string.notification_permission_required)
                         else -> stringResource(R.string.push_off)
                     },
                     date = toastDateTime,

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/GroupNavigationExtensions.kt
@@ -23,12 +23,14 @@ fun NavHostController.navigateToGroupMakeRoomWithBook(
     imageUrl: String,
     author: String
 ) {
-    navigate(GroupRoutes.MakeRoomWithBook(
-        isbn = isbn,
-        title = title,
-        imageUrl = imageUrl,
-        author = author
-    ))
+    navigate(
+        GroupRoutes.MakeRoomWithBook(
+            isbn = isbn,
+            title = title,
+            imageUrl = imageUrl,
+            author = author
+        )
+    )
 }
 
 // 완료된 모임방 목록으로 이동
@@ -90,9 +92,19 @@ fun NavHostController.navigateToGroupNote(
     roomId: Int,
     page: Int? = null,
     isOverview: Boolean? = null,
-    isExpired: Boolean = false
+    isExpired: Boolean = false,
+    postId: Int? = null
 ) {
-    navigate(GroupRoutes.Note(roomId = roomId, page = page, isOverview = isOverview, isExpired = isExpired))
+    navigate(
+        GroupRoutes.Note(
+            roomId = roomId,
+            page = page,
+            openComments = false,
+            isExpired = isExpired,
+            postId = postId,
+            isOverview = isOverview
+        )
+    )
 }
 
 // 기록 생성 화면으로 이동

--- a/app/src/main/java/com/texthip/thip/ui/navigator/extensions/NotificationNavigationExtensions.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/extensions/NotificationNavigationExtensions.kt
@@ -1,0 +1,66 @@
+package com.texthip.thip.ui.navigator.extensions
+
+import android.util.Log
+import androidx.navigation.NavController
+import com.texthip.thip.data.model.notification.response.NotificationCheckResponse
+import com.texthip.thip.data.model.notification.response.NotificationRoute
+import com.texthip.thip.ui.navigator.routes.FeedRoutes
+import com.texthip.thip.ui.navigator.routes.GroupRoutes
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+private fun JsonElement.toStringOrNull(): String? {
+    return (this as? JsonPrimitive)?.contentOrNull
+}
+
+fun NavController.navigateFromNotification(response: NotificationCheckResponse) {
+    val params = response.params
+
+    try {
+        when (response.route) {
+            NotificationRoute.FEED_USER -> {
+                val userId = params["userId"]?.toStringOrNull()?.toLongOrNull()
+                if (userId != null) {
+                    navigate(FeedRoutes.Others(userId))
+                }
+            }
+
+            NotificationRoute.FEED_DETAIL -> {
+                val feedId = params["feedId"]?.toStringOrNull()?.toLongOrNull()
+                if (feedId != null) {
+                    navigate(FeedRoutes.Comment(feedId))
+                }
+            }
+
+            NotificationRoute.ROOM_MAIN -> {
+                val roomId = params["roomId"]?.toStringOrNull()?.toIntOrNull()
+                if (roomId != null) {
+                    navigate(GroupRoutes.Room(roomId))
+                }
+            }
+
+            NotificationRoute.ROOM_DETAIL -> {
+                val roomId = params["roomId"]?.toStringOrNull()?.toIntOrNull()
+                if (roomId != null) {
+                    navigate(GroupRoutes.Recruit(roomId))
+                }
+            }
+
+            NotificationRoute.ROOM_POST_DETAIL -> {
+                val roomId = params["roomId"]?.toStringOrNull()?.toIntOrNull()
+                val page = params["page"]?.toStringOrNull()?.toIntOrNull()
+                val postId = params["postId"]?.toStringOrNull()?.toIntOrNull()
+                val postType = params["postType"]?.toStringOrNull()
+                val openComments =
+                    params["openComments"]?.toStringOrNull()?.toBooleanStrictOrNull() ?: false
+
+                if (roomId != null && page != null) {
+                    navigate(GroupRoutes.Note(roomId, page, openComments, false, postId))
+                }
+            }
+        }
+    } catch (e: Exception) {
+        Log.e("NotificationNav", "Navigation failed", e)
+    }
+}

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/CommonNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/CommonNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.texthip.thip.ui.common.alarmpage.screen.AlarmScreen
 import com.texthip.thip.ui.common.screen.RegisterBookScreen
+import com.texthip.thip.ui.navigator.extensions.navigateFromNotification
 import com.texthip.thip.ui.navigator.routes.CommonRoutes
 
 // Common 관련 네비게이션
@@ -15,10 +16,13 @@ fun NavGraphBuilder.commonNavigation(
     // Alarm 화면
     composable<CommonRoutes.Alarm> {
         AlarmScreen(
-            onNavigateBack = navigateBack
+            onNavigateBack = navigateBack,
+            onNotificationNavigation = { response ->
+                navController.navigateFromNotification(response)
+            }
         )
     }
-    
+
     // 책 요청 화면
     composable<CommonRoutes.RegisterBook> {
         RegisterBookScreen(

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/CommonNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/CommonNavigation.kt
@@ -1,13 +1,9 @@
 package com.texthip.thip.ui.navigator.navigations
 
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import com.texthip.thip.ui.common.alarmpage.screen.AlarmScreen
-import com.texthip.thip.ui.common.alarmpage.viewmodel.AlarmViewModel
 import com.texthip.thip.ui.common.screen.RegisterBookScreen
 import com.texthip.thip.ui.navigator.routes.CommonRoutes
 
@@ -18,12 +14,7 @@ fun NavGraphBuilder.commonNavigation(
 ) {
     // Alarm 화면
     composable<CommonRoutes.Alarm> {
-        val alarmViewModel: AlarmViewModel = viewModel()
-        val alarmItems by alarmViewModel.alarmItems.collectAsState()
-        
         AlarmScreen(
-            alarmItems = alarmItems,
-            onCardClick = { alarmViewModel.onCardClick(it) },
             onNavigateBack = navigateBack
         )
     }

--- a/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/navigations/GroupNavigation.kt
@@ -342,23 +342,14 @@ fun NavGraphBuilder.groupNavigation(
         val route = backStackEntry.toRoute<GroupRoutes.Note>()
         val roomId = route.roomId
         val page = route.page
+        val openComments = route.openComments
         val isOverview = route.isOverview
         val isExpired = route.isExpired
+        val postId = route.postId
 
         val result = backStackEntry.savedStateHandle.get<Int>("selected_tab_index")
 
         val viewModel: GroupNoteViewModel = hiltViewModel(backStackEntry)
-
-        val feedViewModel: FeedViewModel =
-            hiltViewModel(navController.getBackStackEntry(MainTabRoutes.Group))
-        val feedUiState by feedViewModel.uiState.collectAsState()
-        val myUserId = feedUiState.myFeedInfo?.creatorId
-
-        LaunchedEffect(Unit) {
-            if (feedUiState.myFeedInfo == null) {
-                feedViewModel.onTabSelected(1)
-            }
-        }
 
         GroupNoteScreen(
             roomId = roomId,
@@ -366,6 +357,8 @@ fun NavGraphBuilder.groupNavigation(
             initialPage = page,
             initialIsOverview = isOverview,
             isExpired = isExpired,
+            initialPostId = postId,
+            openComments = openComments,
             onResultConsumed = {
                 backStackEntry.savedStateHandle.remove<Int>("selected_tab_index")
             },
@@ -424,11 +417,10 @@ fun NavGraphBuilder.groupNavigation(
                 )
             },
             onNavigateToUserProfile = { userId ->
-                if (myUserId != null && myUserId == userId) {
-                    navController.navigate(FeedRoutes.My)
-                } else {
-                    navController.navigate(FeedRoutes.Others(userId))
-                }
+                navController.navigate(FeedRoutes.Others(userId))
+            },
+            onNavigateToMyProfile = {
+                navController.navigate(FeedRoutes.My)
             },
             viewModel = viewModel
         )

--- a/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
+++ b/app/src/main/java/com/texthip/thip/ui/navigator/routes/GroupRoutes.kt
@@ -43,8 +43,10 @@ sealed class GroupRoutes : Routes() {
     data class Note(
         val roomId: Int,
         val page: Int? = null,
-        val isOverview: Boolean? = null,
-        val isExpired: Boolean = false
+        val openComments: Boolean = false,
+        val isExpired: Boolean = false,
+        val postId: Int? = null,
+        val isOverview: Boolean? = null
     ) : GroupRoutes()
 
     @Serializable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="notification_description">알림센터의 모든 알림을 포함해요</string>
     <string name="push_off">푸시 알림이 해제되었어요.</string>
     <string name="push_on">푸시 알림이 설정되었어요.</string>
+    <string name="notification_permission_required">알림 권한이 필요합니다. 설정에서 권한을 허용해주세요.</string>
 
     <string name="customer_center_email">texthip2025@gmail.com</string>
     <string name="customer_center_description">이메일로 닉네임과 문의사항을 보내주시면</string>


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #140 

<br/>

## 🔎 작업 내용
- [x] 알림 센터 조회 구현
- [x] 알림 센터의 읽음 상태에 따라서 탑바 알림 아이콘 수정
- [x] 알림 읽기 기능 구현
- [x] 알림 읽었을 때 네비게이션 구현

 <br/>

## 📸 스크린샷  
- 알림 센터 조회
https://github.com/user-attachments/assets/55db3423-eede-41c0-97a6-711749868bec

- 알림 센터 아이콘
<img width="413" height="860" alt="스크린샷 2025-09-23 오후 9 55 11" src="https://github.com/user-attachments/assets/bc901f37-0161-46ff-ac9e-9a362683665b" />

<br/>

## 😢 해결하지 못한 과제

 <br/>

## 📢 리뷰어들에게
- 푸시알림 같은 경우에는 앱에 한번 접속해야 FCM 파이어베이스와 연결되어서 이후 푸시알림을 받을 수 있습니다.

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 알림 목록 백엔드 연동(필터: 전체/피드/룸, 무한스크롤, 당겨서 새로고침), 푸시에서 앱 내 특정 화면으로 이동(딥링크) 지원, 푸시 수신 시 목록 자동 갱신, 알림 클릭 시 읽음 처리 및 관련 화면으로 이동, 알림 권한 요청 흐름 및 토스트 안내.
- **Bug Fixes**
  - 알림 필터 칩의 선택 상태 표시 오류 수정.
- **Refactor**
  - 알람 화면을 MVVM 기반으로 전환하여 상태 관리·페이징 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->