### PR TITLE
[FEAT] 미확인 알림 여부 확인 api 연결

### DIFF
--- a/app/src/main/java/com/texthip/thip/data/model/notification/response/NotificationExistsUncheckedResponse.kt
+++ b/app/src/main/java/com/texthip/thip/data/model/notification/response/NotificationExistsUncheckedResponse.kt
@@ -1,0 +1,9 @@
+package com.texthip.thip.data.model.notification.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationExistsUncheckedResponse(
+    @SerialName("exists") val exists: Boolean
+)

--- a/app/src/main/java/com/texthip/thip/data/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/texthip/thip/data/repository/NotificationRepository.kt
@@ -9,6 +9,7 @@ import com.texthip.thip.data.model.notification.request.NotificationCheckRequest
 import com.texthip.thip.data.model.notification.response.NotificationEnabledResponse
 import com.texthip.thip.data.model.notification.response.NotificationListResponse
 import com.texthip.thip.data.model.notification.response.NotificationCheckResponse
+import com.texthip.thip.data.model.notification.response.NotificationExistsUncheckedResponse
 import com.texthip.thip.data.service.NotificationService
 import com.texthip.thip.utils.auth.getAppScopeDeviceId
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -107,5 +108,12 @@ class NotificationRepository @Inject constructor(
 
     fun onNotificationReceived() {
         _notificationRefreshFlow.tryEmit(Unit)
+    }
+
+    suspend fun existsUncheckedNotifications(): Result<NotificationExistsUncheckedResponse?> {
+        return runCatching {
+            val response = notificationService.existsUncheckedNotifications()
+            response.handleBaseResponse().getOrNull()
+        }
     }
 }

--- a/app/src/main/java/com/texthip/thip/data/service/NotificationService.kt
+++ b/app/src/main/java/com/texthip/thip/data/service/NotificationService.kt
@@ -7,6 +7,7 @@ import com.texthip.thip.data.model.notification.request.NotificationCheckRequest
 import com.texthip.thip.data.model.notification.response.NotificationEnabledResponse
 import com.texthip.thip.data.model.notification.response.NotificationListResponse
 import com.texthip.thip.data.model.notification.response.NotificationCheckResponse
+import com.texthip.thip.data.model.notification.response.NotificationExistsUncheckedResponse
 import com.texthip.thip.data.model.base.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -46,4 +47,7 @@ interface NotificationService {
     suspend fun checkNotification(
         @Body request: NotificationCheckRequest
     ): BaseResponse<NotificationCheckResponse>
+
+    @GET("notifications/exists-unchecked")
+    suspend fun existsUncheckedNotifications(): BaseResponse<NotificationExistsUncheckedResponse>
 }

--- a/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmUiState.kt
+++ b/app/src/main/java/com/texthip/thip/ui/common/alarmpage/viewmodel/AlarmUiState.kt
@@ -9,8 +9,8 @@ data class AlarmUiState(
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
     val hasMore: Boolean = true,
-    val error: String? = null
+    val error: String? = null,
+    val hasUnreadNotifications: Boolean = false  // API에서 가져온 읽지 않은 알림 존재 여부
 ) {
     val canLoadMore: Boolean get() = !isLoading && !isLoadingMore && hasMore
-    val hasUnreadNotifications: Boolean get() = notifications.any { !it.isChecked }
 }

--- a/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/feed/screen/FeedScreen.kt
@@ -224,7 +224,7 @@ fun FeedScreen(
     LaunchedEffect(onFeedTabReselected) {
         if (onFeedTabReselected > 0) {
             feedViewModel.refreshOnBottomNavReselect()
-            alarmViewModel.refreshData()
+            alarmViewModel.checkUnreadNotifications()
             currentListState.scrollToItem(0)
         }
     }
@@ -288,7 +288,7 @@ fun FeedScreen(
         onChangeFeedSave = feedViewModel::changeFeedSave,
         onPullToRefresh = {
             feedViewModel.pullToRefresh()
-            alarmViewModel.refreshData()
+            alarmViewModel.checkUnreadNotifications()
         }
     )
 }

--- a/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
+++ b/app/src/main/java/com/texthip/thip/ui/group/screen/GroupScreen.kt
@@ -64,7 +64,7 @@ fun GroupScreen(
     // 화면 재진입 시 데이터 새로고침
     LaunchedEffect(Unit) {
         viewModel.resetToInitialState()
-        alarmViewModel.refreshData()
+        alarmViewModel.checkUnreadNotifications()
     }
     val uiState by viewModel.uiState.collectAsState()
     val alarmUiState by alarmViewModel.uiState.collectAsState()
@@ -80,9 +80,9 @@ fun GroupScreen(
         onNavigateToGroupRecruit = onNavigateToGroupRecruit,
         onNavigateToGroupRoom = onNavigateToGroupRoom,
         onNavigateToGroupSearchAllRooms = onNavigateToGroupSearchAllRooms,
-        onRefreshGroupData = { 
+        onRefreshGroupData = {
             viewModel.refreshGroupData()
-            alarmViewModel.refreshData()
+            alarmViewModel.checkUnreadNotifications()
         },
         onCardVisible = { cardIndex -> viewModel.loadMoreGroups() },
         onSelectGenre = { genreIndex -> viewModel.selectGenre(genreIndex) },


### PR DESCRIPTION
## ➕ 이슈 링크
- closed #145

<br/>

## 🔎 작업 내용

- 미확인 알림 여부 확인 api 연결
- 기존의 알림 여부 확인 로직 수정

 <br/>

## 📸 스크린샷  

- 피드
<img width="401" height="865" alt="스크린샷 2025-10-14 오후 4 50 15" src="https://github.com/user-attachments/assets/919874c5-ebf0-4ac1-a5a4-e5cb2352fa84" />

- 그룹
<img width="401" height="865" alt="스크린샷 2025-10-14 오후 4 50 45" src="https://github.com/user-attachments/assets/920f0f14-a63c-480e-90b0-30efeeddcc6c" />


<br/>

## 😢 해결하지 못한 과제
- [] TASK

  <br/>

## 📢 리뷰어들에게
- 참고해야 할 사항들을 적어주세요

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 서버 기반의 “읽지 않은 알림 존재 여부” 확인을 도입하여 앱 전역에서 상태를 표시합니다.

- 개선
  - 피드/그룹 화면에서 탭 재선택·당겨서 새로고침 시 읽지 않은 알림 상태를 즉시 갱신합니다.
  - 앱 시작 및 알림 상태 변경 후에도 읽지 않은 알림 상태가 자동 동기화됩니다.
  - 배지/아이콘 등 알림 표시의 정확도를 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->